### PR TITLE
Restore call stack

### DIFF
--- a/src/passes/function_passes/CheckPointPass.cpp
+++ b/src/passes/function_passes/CheckPointPass.cpp
@@ -30,20 +30,27 @@ namespace {
 
 /*
  * Insert a `stackmap` call after each call to record its return address.
+ *
+ * The unoptimized version of each function contains the same number of
+ * `llvm.experimental.stackmap` calls as the original (user-defined) version.
+ * Knowing the ID of a `stackmap` call in the optimized version of the function,
+ * the ID of the corresponding call in the unoptimized version can be obtained
+ * by calculating the logical negation of the ID.
  */
 struct CheckPointPass: public FunctionPass {
   static char id;
 
-  // Map the function name to the patchpoint IDs of the stackmap calls
+  // Map each function name to the patchpoint IDs of the stackmap calls
   // in the function. This is used to ensure the runtime can associate the
   // stackmap calls inside each function with stackmap calls from the
-  // unoptimized version of the function
+  // unoptimized version of the function.
   static map<StringRef, vector<uint64_t>> stackMaps;
 
   CheckPointPass() : FunctionPass(id) {}
 
   virtual bool doInitialization(Module &mod) {
-    // Insert the guard failure function.
+    // Declare the guard failure function. This is necessary because the
+    // `__guard_failure` function is not defined in the current module.
     LLVMContext &ctx = mod.getContext();
     Type* i64 = Type::getInt64Ty(ctx);
     FunctionType* signature = FunctionType::get(Type::getVoidTy(ctx),
@@ -59,64 +66,63 @@ struct CheckPointPass: public FunctionPass {
     Module *mod = fun.getParent();
     Type *i8ptr_t = PointerType::getUnqual(
         IntegerType::getInt8Ty(mod->getContext()));
-    // The callback to call when a guard fails
-    Constant* guardHanlder = ConstantExpr::getBitCast(
+    // The callback to call when a guard fails.
+    Constant* guardHandler = ConstantExpr::getBitCast(
         mod->getFunction(GUARD_FUN_NAME), i8ptr_t);
     for (auto &bb : fun) {
       for (BasicBlock::iterator it = bb.begin(); it != bb.end(); ++it) {
+        // XXX This is where the guard must fail (an arbitrary instruction in
+        // the "more_indirection" function).
         if (funName.endswith("more_indirection") && isa<ReturnInst>(it)) {
           LLVMContext &ctx = bb.getContext();
           IRBuilder<> builder(&bb, it);
           uint64_t PPID = getNextPatchpointID(funName);
           // The first two arguments of a stackmap/patchpoint intrinsic call
-          // must be the unique identifier of the call and the number of bytes
-          // in the shadow of the call
+          // are the unique identifier of the call, and the number of bytes
+          // in the shadow of the call.
           auto args = vector<Value*> { builder.getInt64(PPID),
                                        builder.getInt32(13) // XXX shadow
                                       };
           // The intrinsic to call: patchpoint, if the current function is
-          // trace; stackmap, if the current function is __unopt_trace
+          // optimized; stackmap, if the current function is unoptimized.
           Function *intrinsic = nullptr;
-
           if (!funName.startswith(UNOPT_PREFIX)) {
-            // The current function is trace -> insert a patchpoint call. The
-            // arguments of the patchpoint call are: a callback, an integer
-            // which represents the number of arguments of the callback, and
-            // the arguments to pass to the callback.
+            // The current function is an optimized one -> insert a patchpoint
+            // call. The arguments of the patchpoint call are: a callback, an
+            // integer which represents the number of arguments of the
+            // callback, and the arguments to pass to the callback.
             args.insert(args.end(),
-                        { guardHanlder,          // the callback
+                        { guardHandler,          // the callback
                           builder.getInt32(1),   // the callback has one argument
                           builder.getInt64(PPID) // the argument
                         });
             intrinsic = Intrinsic::getDeclaration(
                 mod, Intrinsic::experimental_patchpoint_void);
           } else {
-            // The function is __unopt_trace -> insert a stackmap call instead
-            // of a patchpoint call
+            // The function is not optimized -> insert a stackmap call instead
+            // of a patchpoint call.
             intrinsic = Intrinsic::getDeclaration(
                 mod, Intrinsic::experimental_stackmap);
           }
-
-          auto liveVariables = getLiveRegisters(bb, it);
+          auto liveVariables = getLiveRegisters(*it);
           // Pass the live locations to the stackmap/patchpoint call. This also
           // inserts the size of each 'live' location into the stackmap.
           std::move(liveVariables.begin(), liveVariables.end(),
                     std::back_inserter(args));
-
           auto call_inst = builder.CreateCall(intrinsic, args);
         } else if (isa<CallInst>(it)) {
-          // Insert a stackmap call after each call in which a guard may
-          // fail, in order to be able to work out the correct return address
+          // Insert a stackmap call after each function call inside which a
+          // guard may fail. This enables the runtime to work out the return
+          // address of the function.
           Function *calledFun = cast<CallInst>(*it).getCalledFunction();
           if (!calledFun->hasAvailableExternallyLinkage() &&
               !calledFun->isDeclaration()) {
             uint64_t PPID = getNextPatchpointID(funName);
-            // XXX insert after
             IRBuilder<> builder(&bb, ++it);
             auto args = vector<Value*> { builder.getInt64(PPID),
                                          builder.getInt32(13)  // XXX shadow
                                        };
-            auto liveVariables = getLiveRegisters(bb, it);
+            auto liveVariables = getLiveRegisters(*it);
             std::move(liveVariables.begin(), liveVariables.end(),
                       std::back_inserter(args));
             auto intrinsic = Intrinsic::getDeclaration(
@@ -130,16 +136,15 @@ struct CheckPointPass: public FunctionPass {
     return true;
   }
 
-
   /*
-   * Return the name of 'twin' function of function with the specified name.
+   * Return the name of the 'twin' of the specified function.
    *
-   * If name is the name of an optimized function, then the name of the
-   * function's 'twin' is the name prefixed with '__unopt_'. If the specified
-   * name is the name of an unoptimized function, then this returns the name
-   * of the optimized function (it strips off the '__unopt_' prefix).
+   * If the specified name is the name of an optimized function, then the name
+   * of the function's 'twin' is the name prefixed with '__unopt_'. If the
+   * specified name is the name of an unoptimized function, then this returns
+   * the name of the optimized function (it strips off the '__unopt_' prefix).
    *
-   * "fun" -> "__unopt_fun" or "__unopt_fun" -> "fun"
+   * Example: "fun" -> "__unopt_fun" or "__unopt_fun" -> "fun"
    */
   static std::string getTwinName(StringRef name) {
     if (name.startswith(UNOPT_PREFIX)) {
@@ -148,11 +153,17 @@ struct CheckPointPass: public FunctionPass {
     return UNOPT_PREFIX + name.str();
   }
 
+  /*
+   * Generate a new patchpoint ID for the specified function.
+   */
   static uint64_t getNextPatchpointID(StringRef funName) {
     uint64_t nextPatchpointID = 0;
     if (!stackMaps.empty()) {
         std::string twinFun = getTwinName(funName);
         if (stackMaps.find(twinFun) == stackMaps.end()) {
+          // The `twin` of the function doesn't have any IDs allocated yet.
+          // This means the next ID is equal to the last ID generated for the
+          // current function plus one.
           auto maxPos = std::max_element(stackMaps.begin(), stackMaps.end(),
               [] (const pair<StringRef, vector<uint64_t>> &a,
                     const pair<StringRef, vector<uint64_t>> &b) {
@@ -160,6 +171,9 @@ struct CheckPointPass: public FunctionPass {
               });
           nextPatchpointID = (*maxPos).second.back() + 1;
         } else {
+          // Find (in the `twin` function) the ID of the `stackmap` which
+          // corresponds to the ID currently being generated. Negate the ID
+          // found, to obtain a new ID for the current function.
           size_t lastIndex = stackMaps[funName].size();
           nextPatchpointID = ~stackMaps[twinFun][lastIndex];
         }
@@ -168,29 +182,37 @@ struct CheckPointPass: public FunctionPass {
     return nextPatchpointID;
   }
 
-  static vector<Value *> getLiveRegisters(BasicBlock &bb,
-                                          const BasicBlock::iterator &smIt) {
+  /*
+   * Return the list of registers which are live across the given instruction.
+   */
+  static vector<Value *> getLiveRegisters(Instruction &instr) {
     vector<Value *> args;
-    Function *fun = bb.getParent();
+    Function *fun = instr.getFunction();
     Module *mod = fun->getParent();
     DataLayout dataLayout(mod);
     DominatorTree DT(*fun);
+    // Iterarate over each instruction in the function.
     for (auto &bb : *fun) {
       IRBuilder<> builder(bb.getContext());
       for (BasicBlock::iterator it = bb.begin(); it != bb.end(); ++it) {
-        if (!(*it).use_empty() && !DT.dominates(&(*smIt), &*it)) {
+        if (!(*it).use_empty() && !DT.dominates(&instr, &*it)) {
           for (Value::use_iterator use = (*it).use_begin();
                use != (*it).use_end(); ++use) {
-            if (DT.dominates(&(*smIt), *use)) {
+            // This instruction is defined 'above' `instr` and used 'below'
+            // `instr`, so it is live across `instr`.
+            if (DT.dominates(&instr, *use)) {
               args.push_back(&*it);
               auto instSize = builder.getInt64(8); // XXX default size
+              // The runtime may need to copy more than 8 bytes starting at
+              // this location. We can store the size of the object being
+              // allocated in the stack map.
               if (isa<AllocaInst>(it)) {
                 Type *t = cast<AllocaInst>(*it).getAllocatedType();
                 instSize = builder.getInt64(
                     dataLayout.getTypeAllocSize(t));
               }
-              // also insert the size of the recorded location to know how
-              // many bytes to copy at runtime
+              // Also insert the size of the recorded location to know how
+              // many bytes to copy at runtime.
               args.push_back(instSize);
             }
           }
@@ -214,4 +236,4 @@ static void registerPass(const PassManagerBuilder &,
   PM.add(new CheckPointPass());
 }
 static RegisterStandardPasses RegisterPass(
-PassManagerBuilder::EP_EarlyAsPossible, registerPass);
+    PassManagerBuilder::EP_EarlyAsPossible, registerPass);

--- a/src/passes/function_passes/CheckPointPass.cpp
+++ b/src/passes/function_passes/CheckPointPass.cpp
@@ -19,26 +19,23 @@
 #define UNOPT_PREFIX "__unopt_"
 
 using namespace llvm;
+using std::vector;
+using std::map;
+using std::pair;
 
 namespace {
 
 /*
- * Insert a stackmap call before each call to `putchar`.
- *
- * This only runs on `trace` and `__unopt_trace`. All other functions are
- * ignored.
+ * Insert a `stackmap` call after each call to record its return address.
  */
 struct CheckPointPass: public FunctionPass {
   static char id;
 
-  // The unique identifier of the next stackmap call.
-  static uint64_t sm_id;
-
-  // Map the function name to the ID of the first stackmap/patchpoint call
+  // Map the function name to the patchpoint IDs of the stackmap calls
   // in the function. This is used to ensure the runtime can associate the
   // stackmap calls inside each function with stackmap calls from the
   // unoptimized version of the function
-  static std::map<StringRef, uint64_t> start_sm_id;
+  static map<StringRef, vector<uint64_t>> stackMaps;
 
   CheckPointPass() : FunctionPass(id) {}
 
@@ -54,73 +51,39 @@ struct CheckPointPass: public FunctionPass {
   }
 
   virtual bool runOnFunction(Function &fun) {
-    StringRef fun_name = fun.getName();
-
+    StringRef funName = fun.getName();
     outs() << "Running CheckPointPass on function: " << fun.getName() << '\n';
-
-    // Each function has a corresponding unoptimized version, which starts
-    // with the `__unopt_` prefix (the 'twin').
-    StringRef twin_fun = getTwinName(fun_name);
-
-    // The next stackmap ID to assign
-    uint64_t curr_sm_id = sm_id;
-    if (start_sm_id.find(twin_fun) != start_sm_id.end()) {
-      // If the 'twin' of this function has already been processed, index
-      // stackmap calls starting from ~ID, where ID is the identifier of the
-      // first stackmap call in the 'twin'
-      curr_sm_id = ~start_sm_id[twin_fun];
-    }
-
     Module *mod = fun.getParent();
-    DataLayout data_layout(mod);
-    // sm_id is the ID of the first stackmap call in this function
-    start_sm_id[fun_name] = sm_id;
-    uint64_t call_inst_count = 0;
-
-
     Type *i8ptr_t = PointerType::getUnqual(
         IntegerType::getInt8Ty(mod->getContext()));
     // The callback to call when a guard fails
-    Constant* gf_handler_ptr = ConstantExpr::getBitCast(
+    Constant* guardHanlder = ConstantExpr::getBitCast(
         mod->getFunction(GUARD_FUN_NAME), i8ptr_t);
     for (auto &bb : fun) {
       for (BasicBlock::iterator it = bb.begin(); it != bb.end(); ++it) {
-        if (fun_name.endswith("more_indirection") && isa<ReturnInst>(it)) {
+        if (funName.endswith("more_indirection") && isa<ReturnInst>(it)) {
           LLVMContext &ctx = bb.getContext();
           IRBuilder<> builder(&bb, it);
-          uint64_t patchpoint_id;
-
-          if (start_sm_id.find(twin_fun) == start_sm_id.end()) {
-            // Each stackmap ID is calculated by adding the offset
-            // (call_inst_count) to the 'base' ID (curr_sm_id)
-            patchpoint_id = curr_sm_id + call_inst_count;
-          } else {
-            // If the 'twin' of this function has already been processed,
-            // make sure the ID of each stackmap call in this function can be
-            // obtained from an ID of a stackmap call in the 'twin', by
-            // negating the ID. For example, the patch point with ID `0`
-            // corresponds to the patchpoint with ID `~0 = -1`.
-            patchpoint_id = ~(~curr_sm_id + call_inst_count);
-          }
+          uint64_t PPID = getNextPatchpointID(funName);
           // The first two arguments of a stackmap/patchpoint intrinsic call
           // must be the unique identifier of the call and the number of bytes
           // in the shadow of the call
-          auto args = std::vector<Value*> { builder.getInt64(patchpoint_id),
-                                            builder.getInt32(13) // XXX shadow
-                                          };
+          auto args = vector<Value*> { builder.getInt64(PPID),
+                                       builder.getInt32(13) // XXX shadow
+                                      };
           // The intrinsic to call: patchpoint, if the current function is
           // trace; stackmap, if the current function is __unopt_trace
           Function *intrinsic = nullptr;
 
-          if (!fun_name.startswith(UNOPT_PREFIX)) {
+          if (!funName.startswith(UNOPT_PREFIX)) {
             // The current function is trace -> insert a patchpoint call. The
             // arguments of the patchpoint call are: a callback, an integer
             // which represents the number of arguments of the callback, and
             // the arguments to pass to the callback.
             args.insert(args.end(),
-                        { gf_handler_ptr,      // the callback
-                          builder.getInt32(1), // the callback has one argument
-                          builder.getInt64(patchpoint_id) // the argument
+                        { guardHanlder,          // the callback
+                          builder.getInt32(1),   // the callback has one argument
+                          builder.getInt64(PPID) // the argument
                         });
             intrinsic = Intrinsic::getDeclaration(
                 mod, Intrinsic::experimental_patchpoint_void);
@@ -130,89 +93,38 @@ struct CheckPointPass: public FunctionPass {
             intrinsic = Intrinsic::getDeclaration(
                 mod, Intrinsic::experimental_stackmap);
           }
-          // Pass the live locations to the stackmap/patchpoint call. This also
-          // inserts the size of each 'live' location into the stackmap.
-          for (BasicBlock::iterator prev_inst = bb.begin(); prev_inst != it;
-               ++prev_inst) {
-            // XXX need to accurately identify the live registers - this
-            // currently assumes each instruction in the current basic block to
-            // represent a live location.
-            if (prev_inst != it &&
-                  prev_inst->use_begin() != prev_inst->use_end()) {
-              // Only look at instructions which produce values that have at
-              // least one use. If a result is not used anywhere, it is going
-              // to be removed by future optimization passes, so it should not
-              // be recorded.
-              args.push_back(&*prev_inst);
-              auto size_of_inst = builder.getInt64(8); // XXX default size
-              if (isa<AllocaInst>(prev_inst)) {
-                Type *t = cast<AllocaInst>(*prev_inst).getAllocatedType();
-                size_of_inst = builder.getInt64(
-                    data_layout.getTypeAllocSize(t));
-              }
-              // also insert the size of the recorded location to know how
-              // many bytes to copy at runtime
-              args.push_back(size_of_inst);
-            }
-          }
+
+          auto liveVariables = getLiveRegisters(bb, it);
+          std::move(liveVariables.begin(), liveVariables.end(),
+                    std::back_inserter(args));
+
           auto call_inst = builder.CreateCall(intrinsic, args);
-          ++call_inst_count;
         } else if (isa<CallInst>(it)) {
           // Insert a stackmap call after each call in which a guard may
           // fail, in order to be able to work out the correct return address
-          Function *called_fun = cast<CallInst>(*it).getCalledFunction();
-          if (!called_fun->hasAvailableExternallyLinkage() &&
-              !called_fun->isDeclaration()) {
-            outs() << "Adding SM after call to " << called_fun->getName() << '\n';
-            uint64_t patchpoint_id;
-            if (start_sm_id.find(twin_fun) == start_sm_id.end()) {
-              patchpoint_id = curr_sm_id + call_inst_count;
-            } else {
-              patchpoint_id = ~(~curr_sm_id + call_inst_count);
-            }
+          Function *calledFun = cast<CallInst>(*it).getCalledFunction();
+          if (!calledFun->hasAvailableExternallyLinkage() &&
+              !calledFun->isDeclaration()) {
+            uint64_t PPID = getNextPatchpointID(funName);
             // XXX insert after
             IRBuilder<> builder(&bb, ++it);
-            auto args = std::vector<Value*> { builder.getInt64(patchpoint_id),
-                                              builder.getInt32(13) // XXX shadow
-                                            };
-
-
-            for (BasicBlock::iterator prev_inst = bb.begin(); prev_inst != it;
-                 ++prev_inst) {
-              // XXX need to accurately identify the live registers
-              if (prev_inst != it &&
-                    prev_inst->use_begin() != prev_inst->use_end()) {
-                args.push_back(&*prev_inst);
-                auto size_of_inst = builder.getInt64(8); // XXX
-                if (isa<AllocaInst>(prev_inst)) {
-                  Type *t = cast<AllocaInst>(*prev_inst).getAllocatedType();
-                  size_of_inst = builder.getInt64(
-                      data_layout.getTypeAllocSize(t));
-                }
-                // also insert the size of the recordec location to know how
-                // many bytes to copy at runtime
-                args.push_back(size_of_inst);
-              }
-            }
+            auto args = vector<Value*> { builder.getInt64(PPID),
+                                         builder.getInt32(13)  // XXX shadow
+                                       };
+            auto liveVariables = getLiveRegisters(bb, it);
+            std::move(liveVariables.begin(), liveVariables.end(),
+                      std::back_inserter(args));
             auto intrinsic = Intrinsic::getDeclaration(
                 mod, Intrinsic::experimental_stackmap);
 
             auto call_inst = builder.CreateCall(intrinsic, args);
-            ++call_inst_count;
-          } else {
-            outs() << "Skipping " << *it << '\n';
           }
         }
       }
     }
-    if (start_sm_id.find(twin_fun) == start_sm_id.end()) {
-      // The 'twin' of the function has not yet been processed, which means
-      // sm_id was used as a 'base' ID, so it needs to be updated, since
-      // future functions can no longer use it as a 'base'.
-      sm_id = start_sm_id[fun_name] + call_inst_count;
-    }
     return true;
   }
+
 
   /*
    * Return the name of 'twin' function of function with the specified name.
@@ -224,11 +136,65 @@ struct CheckPointPass: public FunctionPass {
    *
    * "fun" -> "__unopt_fun" or "__unopt_fun" -> "fun"
    */
-  static StringRef getTwinName(StringRef name) {
+  static std::string getTwinName(StringRef name) {
     if (name.startswith(UNOPT_PREFIX)) {
-      return name.substr(StringRef(UNOPT_PREFIX).size());
+      return name.drop_front(StringRef(UNOPT_PREFIX).size()).str();
     }
-    return StringRef(UNOPT_PREFIX + name.str());
+    return UNOPT_PREFIX + name.str();
+  }
+
+  static uint64_t getNextPatchpointID(StringRef funName) {
+    uint64_t nextPatchpointID = 0;
+    if (!stackMaps.empty()) {
+        std::string twinFun = getTwinName(funName);
+        if (stackMaps.find(twinFun) == stackMaps.end()) {
+          auto maxPos = std::max_element(stackMaps.begin(), stackMaps.end(),
+              [] (const pair<StringRef, vector<uint64_t>> &a,
+                    const pair<StringRef, vector<uint64_t>> &b) {
+                return a.second.back() < b.second.back();
+              });
+          nextPatchpointID = (*maxPos).second.back() + 1;
+        } else {
+          size_t lastIndex = stackMaps[funName].size();
+          nextPatchpointID = ~stackMaps[twinFun][lastIndex];
+        }
+    }
+    stackMaps[funName].push_back(nextPatchpointID);
+    return nextPatchpointID;
+  }
+
+  static vector<Value *> getLiveRegisters(BasicBlock &bb,
+                                          const BasicBlock::iterator &it) {
+    vector<Value *> args;
+    IRBuilder<> builder(bb.getContext());
+    Module *mod = bb.getParent()->getParent();
+    DataLayout dataLayout(mod);
+    // Pass the live locations to the stackmap/patchpoint call. This also
+    // inserts the size of each 'live' location into the stackmap.
+    for (BasicBlock::iterator prevInst = bb.begin(); prevInst != it;
+         ++prevInst) {
+      // XXX need to accurately identify the live registers - this
+      // currently assumes each instruction in the current basic block to
+      // represent a live location.
+      if (prevInst != it &&
+            prevInst->use_begin() != prevInst->use_end()) {
+        // Only look at instructions which produce values that have at
+        // least one use. If a result is not used anywhere, it is going
+        // to be removed by future optimization passes, so it should not
+        // be recorded.
+        args.push_back(&*prevInst);
+        auto instSize = builder.getInt64(8); // XXX default size
+        if (isa<AllocaInst>(prevInst)) {
+          Type *t = cast<AllocaInst>(*prevInst).getAllocatedType();
+          instSize = builder.getInt64(
+              dataLayout.getTypeAllocSize(t));
+        }
+        // also insert the size of the recorded location to know how
+        // many bytes to copy at runtime
+        args.push_back(instSize);
+      }
+    }
+    return args;
   }
 
 };
@@ -236,8 +202,7 @@ struct CheckPointPass: public FunctionPass {
 } // end anonymous namespace
 
 char CheckPointPass::id = 0;
-uint64_t CheckPointPass::sm_id = 0;
-std::map<StringRef, uint64_t> CheckPointPass::start_sm_id;
+map<StringRef, vector<uint64_t>> CheckPointPass::stackMaps;
 
 // Automatically enable the pass.
 // http://adriansampson.net/blog/clangpass.html

--- a/src/passes/function_passes/UnoptimizedCopyPass.cpp
+++ b/src/passes/function_passes/UnoptimizedCopyPass.cpp
@@ -45,8 +45,9 @@ struct UnoptimizedCopyPass: public FunctionPass {
    */
   virtual bool runOnFunction(Function &fun) {
     outs() << "Running UnoptCopyPass on function: " << fun.getName() << '\n';
-    auto fun_name = fun.getName();
-    if (fun_name == TRACE_FUN_NAME || fun_name == "more_indirection") {
+    auto funName = fun.getName();
+    if (funName == TRACE_FUN_NAME || funName == "more_indirection"
+        || funName == "get_number") {
       fun.addFnAttr(llvm::Attribute::NoInline);
     } else if (fun.getName().startswith(UNOPT_PREFIX)) {
       fun.addFnAttr(llvm::Attribute::NoInline);
@@ -58,14 +59,14 @@ struct UnoptimizedCopyPass: public FunctionPass {
             // replace each call with a call to the unoptimized version of
             // the called function
             CallInst &call = cast<CallInst>(inst);
-            Function *called_fun = call.getCalledFunction();
-            if (called_fun) {
-              StringRef called_fun_name = called_fun->getName();
-              if (!called_fun_name.startswith(UNOPT_PREFIX)) {
+            Function *calledFun = call.getCalledFunction();
+            if (calledFun) {
+              StringRef calledFunName = calledFun->getName();
+              if (!calledFunName.startswith(UNOPT_PREFIX)) {
                 // not an unoptimized function -> must call the unoptimized
                 // version of the function instead
                 Function *new_fun =
-                  mod->getFunction(UNOPT_PREFIX + called_fun_name.str());
+                  mod->getFunction(UNOPT_PREFIX + calledFunName.str());
                 if (new_fun) {
                   call.setCalledFunction(new_fun);
                 }
@@ -74,17 +75,7 @@ struct UnoptimizedCopyPass: public FunctionPass {
           }
         }
       }
-    } else if (fun_name == "get_number") {
-        //fun.removeFnAttr(llvm::Attribute::OptimizeNone);
-        //fun.removeFnAttr(llvm::Attribute::NoInline);
-        //fun.addFnAttr(llvm::Attribute::AlwaysInline);
-        //
-        fun.addFnAttr(llvm::Attribute::NoInline);
-        fun.addFnAttr(llvm::Attribute::OptimizeNone);
-    } else if (fun_name == "more_indirection") {
-      fun.addFnAttr(llvm::Attribute::NoInline);
     }
-
     return true;
   }
 };

--- a/src/passes/function_passes/UnoptimizedCopyPass.cpp
+++ b/src/passes/function_passes/UnoptimizedCopyPass.cpp
@@ -46,7 +46,7 @@ struct UnoptimizedCopyPass: public FunctionPass {
   virtual bool runOnFunction(Function &fun) {
     outs() << "Running UnoptCopyPass on function: " << fun.getName() << '\n';
     auto fun_name = fun.getName();
-    if (fun_name == TRACE_FUN_NAME) {
+    if (fun_name == TRACE_FUN_NAME || fun_name == "more_indirection") {
       fun.addFnAttr(llvm::Attribute::NoInline);
     } else if (fun.getName().startswith(UNOPT_PREFIX)) {
       fun.addFnAttr(llvm::Attribute::NoInline);
@@ -75,9 +75,8 @@ struct UnoptimizedCopyPass: public FunctionPass {
         }
       }
     } else if (fun_name == "get_number") {
-      fun.removeFnAttr(llvm::Attribute::OptimizeNone);
-      fun.removeFnAttr(llvm::Attribute::NoInline);
-      fun.addFnAttr(llvm::Attribute::AlwaysInline);
+      fun.addFnAttr(llvm::Attribute::NoInline);
+      fun.addFnAttr(llvm::Attribute::OptimizeNone);
     }
 
     return true;

--- a/src/passes/function_passes/UnoptimizedCopyPass.cpp
+++ b/src/passes/function_passes/UnoptimizedCopyPass.cpp
@@ -75,8 +75,14 @@ struct UnoptimizedCopyPass: public FunctionPass {
         }
       }
     } else if (fun_name == "get_number") {
+        //fun.removeFnAttr(llvm::Attribute::OptimizeNone);
+        //fun.removeFnAttr(llvm::Attribute::NoInline);
+        //fun.addFnAttr(llvm::Attribute::AlwaysInline);
+        //
+        fun.addFnAttr(llvm::Attribute::NoInline);
+        fun.addFnAttr(llvm::Attribute::OptimizeNone);
+    } else if (fun_name == "more_indirection") {
       fun.addFnAttr(llvm::Attribute::NoInline);
-      fun.addFnAttr(llvm::Attribute::OptimizeNone);
     }
 
     return true;

--- a/src/stackmap_checker/Makefile
+++ b/src/stackmap_checker/Makefile
@@ -24,4 +24,4 @@ $(EXECUTABLE).o: $(EXECUTABLE).ll
 	$(CC) $(PASSFLAGS) -S -emit-llvm $< -O3
 
 clean:
-	rm -f $(EXECUTABLE) *.o *.ll
+	rm -f $(EXECUTABLE) *.o *.ll /tmp/__stack_resizer_*

--- a/src/stackmap_checker/Makefile
+++ b/src/stackmap_checker/Makefile
@@ -1,11 +1,9 @@
 CC = clang
 LLC = ../llvm/build/bin/llc
-CFLAGS := -g $(shell llvm-config --cflags) -Wno-language-extension-token
-LDFLAGS := $(shell llvm-config  --cflags --ldflags --libs all --system-libs) -lstdc++
 CPOINTPASS := -Xclang -load -Xclang ../passes/build/function_passes/libCheckPointPass.so
 UNOPTPASS := -Xclang -load -Xclang ../passes/build/function_passes/libUnoptimizedCopyPass.so
 PASSFLAGS := $(CPOINTPASS) $(UNOPTPASS)
-OBJS := utils.o stmap.o jump.o
+OBJS := utils.o stmap.o jump.o guard.o
 EXECUTABLE := trace
 
 .PHONY: all clean
@@ -13,7 +11,7 @@ EXECUTABLE := trace
 all: $(EXECUTABLE)
 
 trace: $(OBJS) $(EXECUTABLE).o
-	$(CC) $(PASSFLAGS) -o $@ $(OBJS) $(EXECUTABLE).o -O3
+	$(CC) $(PASSFLAGS) -o $@ $(OBJS) $(EXECUTABLE).o -O3 -lunwind
 
 bytecode: $(EXECUTABLE).c
 	$(CC) $(PASSFLAGS) -S -emit-llvm $< -O3

--- a/src/stackmap_checker/guard.c
+++ b/src/stackmap_checker/guard.c
@@ -18,6 +18,52 @@ extern void restore_and_jmp(void);
 uint64_t addr = 0;
 uint64_t r[16];
 
+int get_direct_locations(stack_map_t *sm, void *bp, stack_map_record_t *recs,
+        uint32_t rec_count, uint64_t **direct_locs)
+{
+    // Restore the stack
+    int num_locations = 0;
+    uint64_t new_size = 0;
+    for (int i = 0; i < rec_count; ++i) {
+        stack_map_record_t opt_rec = recs[i];
+        stack_map_record_t *unopt_rec =
+            stmap_get_map_record(sm, ~opt_rec.patchpoint_id);
+        new_size += opt_rec.num_locations / 2 * sizeof(uint64_t);
+        *direct_locs = (uint64_t *)realloc(*direct_locs, new_size);
+        printf("Direct locs %p size %d\n", *direct_locs, new_size);
+        // Populate the stack of the optimized function with the values the
+        // unoptimized function expects
+        for (int i = 0; i < unopt_rec->num_locations - 1; i += 2) {
+            location_type type = unopt_rec->locations[i].kind;
+            printf("Record %d\n", i);
+            uint64_t opt_location_value =
+                stmap_get_location_value(sm, opt_rec.locations[i], r, bp);
+            if (type == REGISTER) {
+                uint16_t reg_num = unopt_rec->locations[i].dwarf_reg_num;
+                uint64_t loc_size =
+                    stmap_get_location_value(sm, opt_rec.locations[i + 1], r, bp);
+                memcpy(r + reg_num, &opt_location_value, loc_size);
+            } else if (type == DIRECT) {
+                printf("Direct\n");
+                uint64_t loc_size =
+                    stmap_get_location_value(sm, opt_rec.locations[i + 1], r, bp);
+                printf("At index %d at depth %d saving %lu of size %d\n",
+                        num_locations, i, opt_location_value,
+                        loc_size);
+                memcpy(*direct_locs + num_locations, &opt_location_value,
+                       loc_size);
+                ++num_locations;
+            } else if (type == INDIRECT) {
+                uint64_t unopt_addr = (uint64_t) bp + unopt_rec->locations[i].offset;
+                errx(1, "Not implemented - indirect.\n");
+            } else if (type != CONSTANT && type != CONST_INDEX) {
+                errx(1, "Unknown record - %u. Exiting\n", type);
+            }
+        }
+    }
+    return num_locations;
+}
+
 void __guard_failure(int64_t sm_id)
 {
     // save register the state in global array r
@@ -50,7 +96,7 @@ void __guard_failure(int64_t sm_id)
     unw_word_t stack_ptr;
 
     // XXX
-    uint64_t **ret_addrs = malloc(MAX_CALL_STACK_DEPTH * sizeof(uint64_t *));
+    uint64_t **ret_addrs = calloc(MAX_CALL_STACK_DEPTH, sizeof(uint64_t *));
     size_t idx = 0;
     while (unw_step(&cursor) > 0) {
         unw_word_t off, pc;
@@ -59,95 +105,121 @@ void __guard_failure(int64_t sm_id)
             break;
         }
         unw_get_reg(&cursor, UNW_REG_SP, &stack_ptr);
-
-        // 1. find base pointer of each function
-        // 2. replace return addresses with addresses from unopt
-        // 3. Restore all the stacks in the call stack
+        // Find base pointer of each function.
         char fun_name[128];
-        int ret = !unw_get_proc_name(&cursor, fun_name, sizeof(fun_name), &off);
-
+        unw_get_proc_name(&cursor, fun_name, sizeof(fun_name), &off);
         if (idx > 0) {
             ret_addrs[idx - 1] = (uint64_t *)((char *)stack_ptr - 8);
         }
         idx++;
-
         if (!strcmp(fun_name, "main")) {
+            // --idx; ??
             break;
         }
     }
-    size_t call_stack_depth = idx > 0 ? idx - 1 : 0;
+
     void *stack_map_addr = get_addr(".llvm_stackmaps");
     if (!stack_map_addr) {
         errx(1, ".llvm_stackmaps section not found. Exiting.\n");
     }
-
     stack_map_t *sm = stmap_create(stack_map_addr);
-    for (int i = 0; i < call_stack_depth; ++i) {
-        printf("* Ret addr %p\n", *(uint64_t *)ret_addrs[i]);
-        uint64_t unopt_ret_addr =
-            stmap_get_unopt_return_addr(sm, *ret_addrs[i]);
-        printf("Using %p instead\n", unopt_ret_addr);
-        *ret_addrs[i] = unopt_ret_addr;
-    }
-    return ;
-    void *bp = __builtin_frame_address(1);
+    stmap_print_stack_size_records(sm);
 
-    int unopt_rec_idx = stmap_get_map_record(sm, ~sm_id);
-    int opt_rec_idx = stmap_get_map_record(sm, sm_id);
+    // Overwrite the old return addresses
+    size_t call_stack_depth = idx > 0 ? idx - 1 : 0;
 
-    if (unopt_rec_idx == -1 || opt_rec_idx == -1) {
+    // Need call_stack_depth + 1 stack maps (1 = the patchpoint which failed);
+    // This stores the stack map records of the optimized trace
+    stack_map_record_t *call_stk_records = calloc(call_stack_depth + 1,
+                                                  sizeof(stack_map_record_t));
+
+    stack_map_record_t *unopt_rec = stmap_get_map_record(sm, ~sm_id);
+    stack_map_record_t *opt_rec = stmap_get_map_record(sm, sm_id);
+
+    if (!unopt_rec || !opt_rec) {
         errx(1, "Stack map record not found. Exiting.\n");
     }
+    call_stk_records[0] = *opt_rec;
 
+    void *bp = __builtin_frame_address(1);
 
-    stack_map_record_t unopt_rec = sm->stk_map_records[unopt_rec_idx];
-    stack_map_record_t opt_rec = sm->stk_map_records[opt_rec_idx];
-
-    stack_size_record_t unopt_size_rec =
-        sm->stk_size_records[stmap_get_size_record(sm, unopt_rec_idx)];
-
-    stack_size_record_t opt_size_rec =
-        sm->stk_size_records[stmap_get_size_record(sm, opt_rec_idx)];
-
-    // Restore the stack
-    uint64_t *direct_locations =
-        (uint64_t *)malloc(sizeof(uint64_t) * unopt_rec.num_locations);
-    // Populate the stack of the optimized function with the values the
-    // unoptimized function expects
-    for (int i = 1; i < unopt_rec.num_locations - 1; i += 2) {
-        location_type type = unopt_rec.locations[i].kind;
-        uint64_t opt_location_value =
-            stmap_get_location_value(sm, opt_rec.locations[i], r, bp);
-        if (type == REGISTER) {
-            uint16_t reg_num = unopt_rec.locations[i].dwarf_reg_num;
-            uint64_t loc_size =
-                stmap_get_location_value(sm, opt_rec.locations[i + 1], r, bp);
-            memcpy(r + reg_num, &opt_location_value, loc_size);
-        } else if (type == DIRECT) {
-            uint64_t loc_size =
-                stmap_get_location_value(sm, opt_rec.locations[i + 1], r, bp);
-            memcpy(direct_locations + i, &opt_location_value,
-                    loc_size);
-        } else if (type == INDIRECT) {
-            uint64_t unopt_addr = (uint64_t) bp + unopt_rec.locations[i].offset;
-            errx(1, "Not implemented - indirect.\n");
-        } else if (type != CONSTANT && type != CONST_INDEX) {
-            errx(1, "Unknown record - %u. Exiting\n", type);
-        }
+    stmap_print_map_record(sm, opt_rec->index, r, bp);
+    for (int i = 0; i < call_stack_depth; ++i) {
+        printf("* Ret addr %p\n", (void *)*(uint64_t *)ret_addrs[i]);
+        stack_map_pos_t *sm_pos =
+            stmap_get_unopt_return_addr(sm, *(uint64_t *)ret_addrs[i]);
+        uint64_t unopt_ret_addr =
+            sm->stk_size_records[sm_pos->stk_size_record_index].fun_addr +
+            sm->stk_map_records[sm_pos->stk_map_record_index].instr_offset;
+        printf("* Using %p instead\n", (void *)unopt_ret_addr);
+        *ret_addrs[i] = unopt_ret_addr;
+        stack_map_record_t *opt_stk_map_rec =
+            stmap_get_map_record(
+                sm,
+                ~sm->stk_map_records[sm_pos->stk_map_record_index].patchpoint_id);
+        call_stk_records[i + 1] =
+            sm->stk_map_records[sm_pos->stk_map_record_index];
+        stmap_print_map_record(sm, sm_pos->stk_map_record_index, r, bp);
     }
 
-    for (int i = 1; i < unopt_rec.num_locations - 1; i += 2) {
-        location_type type = unopt_rec.locations[i].kind;
-        if (type == DIRECT) {
-            uint64_t unopt_addr = (uint64_t)bp + unopt_rec.locations[i].offset;
-            uint64_t loc_size =
-                stmap_get_location_value(sm, opt_rec.locations[i + 1], r, bp);
-            memcpy((void *)unopt_addr, direct_locations + i, loc_size);
+    stack_size_record_t *unopt_size_rec =
+        stmap_get_size_record(sm, unopt_rec->index);
+    stack_size_record_t *opt_size_rec =
+        stmap_get_size_record(sm, opt_rec->index);
+
+    if (!unopt_size_rec || !opt_size_rec) {
+        errx(1, "Record not found.");
+    }
+
+    uint64_t *direct_locations = NULL;
+    int num_locations = get_direct_locations(sm, bp, call_stk_records,
+                                             call_stack_depth + 1,
+                                             &direct_locations);
+    printf("Locations %d\n", num_locations);
+    for (int i = 0; i < num_locations; ++i) {
+        printf("Location %d %lu\n", i, direct_locations[i]);
+    }
+    printf("Restoring SM records\n");
+    int loc_index = 0;
+    // Restore all the stacks on the call stack
+    for (int i = 0; i < call_stack_depth + 1; ++i) {
+        stack_map_record_t unopt_rec = call_stk_records[i];
+        stack_map_record_t *opt_rec =
+            stmap_get_map_record(sm, ~unopt_rec.patchpoint_id);
+        if (!opt_rec) {
+            errx(1, "Optimized stack map record not found.\n");
+        }
+
+        printf("Depth %d / %d\n", i, call_stack_depth);
+        // Populate the stack of the optimized function with the values the
+        // unoptimized function expects
+        for (int i = 0; i < unopt_rec.num_locations - 1; i += 2) {
+            location_type type = unopt_rec.locations[i].kind;
+            printf("Record %d / %d loc index %d\n",
+                    i, unopt_rec.num_locations, loc_index);
+            uint64_t opt_location_value = direct_locations[loc_index];
+            printf("Opt location val %p\n", (void *)opt_location_value);
+            if (type == DIRECT) {
+                uint64_t unopt_addr = (uint64_t)bp + unopt_rec.locations[i].offset;
+                uint64_t loc_size =
+                    stmap_get_location_value(sm, opt_rec->locations[i + 1], r, bp);
+                printf("Location size %lu\n", loc_size);
+                printf("memcpy %lu @ %p\n", opt_location_value, (void*)unopt_addr);
+                memcpy((void *)unopt_addr, &opt_location_value,
+                        loc_size);
+                ++loc_index;
+            }
         }
     }
-    addr = unopt_size_rec.fun_addr + unopt_rec.instr_offset;
-    stmap_free(sm);
-    free(direct_locations);
+    // The address to jump to
+    addr = unopt_size_rec->fun_addr + unopt_rec->instr_offset;
+
+    /*stmap_free(sm);*/
+    /*free(direct_locations);*/
+
+    for (int i = 0; i < call_stack_depth; ++i) {
+        printf("* Ret addr %p\n", (void *)*(uint64_t *)ret_addrs[i]);
+    }
     asm volatile("jmp restore_and_jmp");
 }
 

--- a/src/stackmap_checker/guard.c
+++ b/src/stackmap_checker/guard.c
@@ -1,5 +1,5 @@
-#define UNW_LOCAL_ONLY
-
+#include "stmap.h"
+#include "utils.h"
 #include <stdint.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -7,20 +7,37 @@
 #include <string.h>
 #include <err.h>
 #include <signal.h>
+#define UNW_LOCAL_ONLY
 #include <libunwind.h>
-#include "stmap.h"
-#include "utils.h"
 
 #define MAX_CALL_STACK_DEPTH 256
+// XXX Need a portable way of obtaining the name of the executable
+#define TRACE_BIN "trace"
 
+// XXX These currently need to be global, since they need to be visible to
+// jump.s
+// The label to jump to whenever a guard fails.
+extern void restore_and_jmp(void);
+// The address to jump to.
+uint64_t addr = 0;
+
+// The state of the call stack.
 typedef struct CallStackState {
+    // The address of the return address of each frame.
     uint64_t *ret_addrs;
+    // The base pointers.
     unw_word_t *bps;
+    // The 16 registers recorded for each frame.
     unw_word_t **registers;
+    // The stack map records which correspond to each call on the stack.
     stack_map_record_t *records;
+    // The number of frames on the stack.
     uint32_t depth;
 } call_stack_state_t;
 
+/*
+ * Return the state of the call stack.
+ */
 call_stack_state_t* get_call_stack_state(unw_cursor_t cursor,
                                          unw_context_t context)
 {
@@ -34,6 +51,15 @@ call_stack_state_t* get_call_stack_state(unw_cursor_t cursor,
         if (!pc) {
             break;
         }
+
+        char fun_name[128];
+        unw_get_proc_name(&cursor, fun_name, sizeof(fun_name), &off);
+
+        // Stop when main is reached.
+        if (!strcmp(fun_name, "main")) {
+            break;
+        }
+
         if (!registers[frame]) {
             // 16 registers are saved for each frame
             registers[frame] = calloc(16, sizeof(unw_word_t));
@@ -54,21 +80,12 @@ call_stack_state_t* get_call_stack_state(unw_cursor_t cursor,
         unw_get_reg(&cursor, UNW_X86_64_R13, &registers[frame][13]);
         unw_get_reg(&cursor, UNW_X86_64_R14, &registers[frame][14]);
         unw_get_reg(&cursor, UNW_X86_64_R15, &registers[frame][15]);
-
-        // Find base pointer of each function.
-        char fun_name[128];
-        unw_get_proc_name(&cursor, fun_name, sizeof(fun_name), &off);
-        printf("Found ret addr %p\n",
-            *(uint64_t *)((char *)registers[frame][6] + 8));
+        // Find address of the return address.
         ret_addrs[frame] =
-            (uint64_t)((char *)registers[frame][UNW_X86_64_RBP] + 8);
+            (uint64_t)(registers[frame][UNW_X86_64_RBP] + 8);
+        // Store the current BP.
         *(bps + frame) = registers[frame][UNW_X86_64_RBP];
         frame++;
-        if (!strcmp(fun_name, "main")) {
-            --frame;
-            free (registers[frame]);
-            break;
-        }
     }
 
     call_stack_state_t *state = malloc(sizeof(call_stack_state_t));
@@ -92,22 +109,22 @@ void free_call_stack_state(call_stack_state_t *state)
     free(state);
 }
 
-// the label to jump to whenever a guard fails
-extern void restore_and_jmp(void);
-uint64_t addr = 0;
-
-int get_direct_locations(stack_map_t *sm, call_stack_state_t *state,
-        uint64_t **direct_locs)
+/*
+ * Return all the locations recorded in the stack map `sm` for each of
+ * the frames in `state`. The direct locations need to be restored later.
+ */
+size_t get_locations(stack_map_t *sm, call_stack_state_t *state,
+                     uint64_t **locs)
 {
-    int num_locations = 0;
-    uint64_t new_size = 0;
+    size_t num_locations = 0;
+    size_t new_size = 0;
     // Each record corresponds to a stack frame.
     for (int i = 0; i < state->depth; ++i) {
         stack_map_record_t opt_rec = state->records[i];
         stack_map_record_t *unopt_rec =
             stmap_get_map_record(sm, ~opt_rec.patchpoint_id);
         new_size += opt_rec.num_locations * sizeof(uint64_t);
-        *direct_locs = (uint64_t *)realloc(*direct_locs, new_size);
+        *locs = (uint64_t *)realloc(*locs, new_size);
         // Populate the stack of the optimized function with the values the
         // unoptimized function expects
         for (int j = 0; j < unopt_rec->num_locations - 1; j += 2) {
@@ -122,23 +139,21 @@ int get_direct_locations(stack_map_t *sm, call_stack_state_t *state,
                                          state->registers[i],
                                          (void *)state->bps[i]);
             if (type == DIRECT) {
-                printf("Direct\n");
-                memcpy(*direct_locs + num_locations, &opt_location_value,
-                       loc_size);
+                memcpy(*locs + num_locations, &opt_location_value, loc_size);
                 ++num_locations;
-                memcpy(*direct_locs + num_locations, &loc_size, sizeof(uint64_t));
+                memcpy(*locs + num_locations, &loc_size, sizeof(uint64_t));
                 ++num_locations;
             } else if (type == REGISTER) {
-                memcpy(*direct_locs + num_locations, &opt_location_value,
-                       loc_size);
+                memcpy(*locs + num_locations, &opt_location_value, loc_size);
                 ++num_locations;
-                memcpy(*direct_locs + num_locations, &loc_size, sizeof(uint64_t));
+                memcpy(*locs + num_locations, &loc_size, sizeof(uint64_t));
                 ++num_locations;
             } else if (type == INDIRECT) {
-                uint64_t unopt_addr = (uint64_t)state->bps[i] +
-                    unopt_rec->locations[j].offset;
                 errx(1, "Not implemented - indirect.\n");
-            } else if (type != CONSTANT && type != CONST_INDEX && type != REGISTER) {
+            } else if (type != CONSTANT && type != CONST_INDEX) {
+                // A type which is not CONSTANT or CONST_INDEX is considered
+                // unknown (no other types are defined in the stack map
+                // documentation).
                 errx(1, "Unknown record - %u. Exiting\n", type);
             }
         }
@@ -146,57 +161,29 @@ int get_direct_locations(stack_map_t *sm, call_stack_state_t *state,
     return num_locations;
 }
 
-void print_registers(size_t frame, unw_word_t **registers)
-{
-    printf("Registers in frame %d\n", frame);
-    printf("\tRAX: %lu\n", registers[frame][UNW_X86_64_RAX]);
-    printf("\tRCX: %lu\n", registers[frame][UNW_X86_64_RCX]);
-    printf("\tRDX: %lu\n", registers[frame][UNW_X86_64_RDX]);
-    printf("\tRBX: %lu\n", registers[frame][UNW_X86_64_RBX]);
-    printf("\tRSP: %lu\n", registers[frame][UNW_X86_64_RSP]);
-    printf("\tRBP: %lu\n", registers[frame][UNW_X86_64_RBP]);
-    printf("\tRSI: %lu\n", registers[frame][UNW_X86_64_RSI]);
-    printf("\tRDI: %lu\n", registers[frame][UNW_X86_64_RDI]);
-    printf("\tR8: %lu\n", registers[frame][UNW_X86_64_R8]);
-    printf("\tR9: %lu\n", registers[frame][UNW_X86_64_R9]);
-    printf("\tR10: %lu\n", registers[frame][UNW_X86_64_R10]);
-    printf("\tR11: %lu\n", registers[frame][UNW_X86_64_R11]);
-    printf("\tR12: %lu\n", registers[frame][UNW_X86_64_R12]);
-    printf("\tR13: %lu\n", registers[frame][UNW_X86_64_R13]);
-    printf("\tR14: %lu\n", registers[frame][UNW_X86_64_R14]);
-    printf("\tR15: %lu\n", registers[frame][UNW_X86_64_R15]);
-}
-
-void print_return_addrs(uint64_t **ret_addrs, size_t call_stack_depth)
-{
-    for (int frame = 0; frame < call_stack_depth; ++frame) {
-        printf("* Ret addr %p @ %p\n", (void *)*(uint64_t *)ret_addrs[frame],
-                ret_addrs[frame]);
-    }
-}
-
 void restore_unopt_stack(stack_map_t *sm, call_stack_state_t *state,
                          stack_map_record_t *unopt_rec,
                          stack_map_record_t *opt_rec)
 {
-    // Need call_stack_depth + 1 stack maps (1 = the patchpoint which failed);
     // This stores the stack map records of the unoptimized trace
     stack_map_record_t *unopt_call_stk_records = calloc(state->depth,
                                                   sizeof(stack_map_record_t));
-
     state->records = calloc(state->depth, sizeof(stack_map_record_t));
-
-
-    // Overwrite the old return addresses and store the stack map records
-    // that correspond to each call which generated this stack trace in
-    // unopt_call_stk_records.
+    // Overwrite the old return addresses and store the stack map records that
+    // correspond to each call which generated this stack trace in
+    // `unopt_call_stk_records`.
     unopt_call_stk_records[0] = *unopt_rec;
+    // The first stack map record to be stored is the one associated with the
+    // patchpoint which triggered the guard failure.
     state->records[0] = *opt_rec;
-    stmap_print_map_record(sm, opt_rec->index, state->registers[0],
-                           (void *)state->bps[0]);
-    // Loop depth - 1 times, because the return address of 'trace'
-    // should not be overwritten (it should still return in main)
+    // Loop `depth - 1` times, because the return address of 'trace' should not
+    // be overwritten (it should still return in main)
     for (int i = 0; i < state->depth - 1; ++i) {
+        // `sm_pos` identifies a position in a function. It is essentially an
+        // address. A stack map record is always associated with a stack size
+        // record. Each stack size record uniquely identifies a function, while
+        // a stack map record contains the offset of the `stackmap` call in the
+        // function.
         stack_map_pos_t *sm_pos =
             stmap_get_unopt_return_addr(sm, *(uint64_t *)state->ret_addrs[i]);
         uint64_t unopt_ret_addr =
@@ -204,99 +191,144 @@ void restore_unopt_stack(stack_map_t *sm, call_stack_state_t *state,
             sm->stk_map_records[sm_pos->stk_map_record_index].instr_offset;
         // Overwrite the old return addresses
         *(uint64_t *)state->ret_addrs[i] = unopt_ret_addr;
+        // The stack map record associated with this frame.
         stack_map_record_t *opt_stk_map_rec =
             stmap_get_map_record(
                 sm,
                 ~sm->stk_map_records[sm_pos->stk_map_record_index].patchpoint_id);
+        // The unoptimized counterpart of the record above.
         unopt_call_stk_records[i + 1] =
             sm->stk_map_records[sm_pos->stk_map_record_index];
 
+        // Store each record that corresponds to a frame on the call stack.
         state->records[i + 1] = *opt_stk_map_rec;
         free(sm_pos);
     }
 
-    uint64_t *direct_locations = NULL;
-    int num_locations = get_direct_locations(sm, state, &direct_locations);
+    uint64_t *locations = NULL;
+    // Get all the locations that are 'live' in the 'optimized' version of the
+    // call stack. These need to be restored, so that execution can resume in
+    // the 'unoptimized' version. The 'unoptimized' version only contains calls
+    // to `__unopt_` functions.
+    size_t num_locations = get_locations(sm, state, &locations);
 
+    // Used to index `locations`.
     int loc_index = 0;
     // Restore all the stacks on the call stack
     for (int frame = 0; frame < state->depth; ++frame) {
+        // Get the unoptimized stack map record associated with this frame.
         stack_map_record_t unopt_rec = unopt_call_stk_records[frame];
-
-        stmap_print_map_record(sm, unopt_rec.index,
-                               state->registers[frame],
-                               (void *)state->bps[frame]);
         // Populate the stack of the optimized function with the values the
-        // unoptimized function expects
+        // unoptimized function expects.
+        // Records are considered in pairs (the counter is incremented by 2),
+        // because each record at an odd index in the array represents the
+        // size of the previous record.
         for (int j = 0; j < unopt_rec.num_locations - 1; j += 2) {
             location_type type = unopt_rec.locations[j].kind;
-            uint64_t opt_location_value = direct_locations[loc_index];
-            uint64_t loc_size = direct_locations[loc_index + 1];
+            uint64_t opt_location_value = locations[loc_index];
+            uint64_t loc_size = locations[loc_index + 1];
             if (type == DIRECT) {
                 uint64_t unopt_addr = (uint64_t)state->bps[frame] +
                     unopt_rec.locations[j].offset;
+                // Place the live location at the correct stack location.
                 memcpy((void *)unopt_addr, &opt_location_value,
                         loc_size);
                 loc_index += 2;
             } else if (type == REGISTER) {
                 uint64_t reg_num = unopt_rec.locations[j].dwarf_reg_num;
+                // Save the new value of the register (it is restored later).
                 memcpy(state->registers[frame] + reg_num,
                        &opt_location_value, loc_size);
                 loc_index += 2;
+            } else if (type == INDIRECT) {
+                errx(1, "Not implemented - indirect.\n");
+            } else if (type != CONSTANT && type != CONST_INDEX) {
+                errx(1, "Unknown record - %u. Exiting\n", type);
             }
         }
     }
-    free(direct_locations);
+    free(locations);
     free(unopt_call_stk_records);
 }
 
+/*
+ * The guard failure handler. This is the callback passed to the `patchpoint`
+ * call which represents a guard failure. When the `patchpoint` instruction is
+ * executed, the callback is called.
+ */
 void __guard_failure(int64_t sm_id)
 {
-    printf("Guard %ld failed!\n", sm_id);
+    fprintf(stderr, "Guard %ld failed!\n", sm_id);
 
     unw_cursor_t cursor;
     unw_context_t context;
     unw_getcontext(&context);
     unw_init_local(&cursor, &context);
     unw_cursor_t saved_cursor = cursor;
-
+    // Get the call stack state.
     call_stack_state_t *state = get_call_stack_state(cursor, context);
 
+    // Read the stack map section.
     void *stack_map_addr = get_addr(".llvm_stackmaps");
     if (!stack_map_addr) {
         errx(1, ".llvm_stackmaps section not found. Exiting.\n");
     }
     stack_map_t *sm = stmap_create(stack_map_addr);
-    stack_map_record_t *unopt_rec = stmap_get_map_record(sm, ~sm_id);
-    stack_map_record_t *opt_rec = stmap_get_map_record(sm, sm_id);
 
+    // The stack map records which correspond to the optimized/unoptimized
+    // versions of the function in which the guard failed.
+    stack_map_record_t *opt_rec = stmap_get_map_record(sm, sm_id);
+    stack_map_record_t *unopt_rec = stmap_get_map_record(sm, ~sm_id);
     if (!unopt_rec || !opt_rec) {
         errx(1, "Stack map record not found. Exiting.\n");
     }
+
+    // The stack size records associated with the map records above.
     stack_size_record_t *unopt_size_rec =
         stmap_get_size_record(sm, unopt_rec->index);
     stack_size_record_t *opt_size_rec =
         stmap_get_size_record(sm, opt_rec->index);
-
     if (!unopt_size_rec || !opt_size_rec) {
         errx(1, "Record not found.");
     }
-    // get the end address of the function in which a guard failed
-    void *end_addr = get_sym_end((void *)opt_size_rec->fun_addr, "trace");
+
+    // Get the end address of the function in which a guard failed.
+    void *end_addr = get_sym_end((void *)opt_size_rec->fun_addr, TRACE_BIN);
     uint64_t callback_ret_addr = (uint64_t) __builtin_return_address(0);
+    // Check if the guard failed in an inlined function or not.
     if (callback_ret_addr >= opt_size_rec->fun_addr &&
         callback_ret_addr < (uint64_t)end_addr) {
-        printf("A guard failed, but not in an inlined func\n");
-
+        fprintf(stderr, "A guard failed, but not in an inlined func\n");
     } else {
-        printf("A guard failed in an inlined function.\n");
+        fprintf(stderr, "A guard failed in an inlined function.\n");
+        // XXX WIP
+        stack_map_record_t *rec = stmap_first_rec_after_addr(sm,
+                callback_ret_addr);
+        stack_size_record_t *size_rec =
+            stmap_get_size_record(sm, rec->index);
+        // Find the 'return addresses' of the inlined functions
+        while(rec->instr_offset + size_rec->fun_addr != state->ret_addrs[0]) {
+            stack_map_record_t *unopt_rec =
+                stmap_get_map_record(sm, ~rec->patchpoint_id);
+            stack_size_record_t *unopt_size_rec =
+                stmap_get_size_record(sm, unopt_rec->index);
+            rec =
+                stmap_first_rec_after_addr(sm,
+                                rec->instr_offset + size_rec->fun_addr + 1);
+            if (!rec) {
+                break;
+            }
+            size_rec = stmap_get_size_record(sm, rec->index);
+            if (!size_rec) {
+                errx(1, "Size record not found\n");
+            }
+        }
         exit(1);
     }
+
+    // Restore the stack state.
     restore_unopt_stack(sm, state, unopt_rec, opt_rec);
-
-    // The address to jump to
-    addr = unopt_size_rec->fun_addr + unopt_rec->instr_offset;
-
+    // Restore the register state.
     uint32_t frame = 0;
     while (unw_step(&saved_cursor) > 0) {
         unw_word_t off, pc;
@@ -310,6 +342,8 @@ void __guard_failure(int64_t sm_id)
         }
         ++frame;
     }
+    // The address to jump to
+    addr = unopt_size_rec->fun_addr + unopt_rec->instr_offset;
     stmap_free(sm);
     free_call_stack_state(state);
     asm volatile("jmp restore_and_jmp");

--- a/src/stackmap_checker/guard.c
+++ b/src/stackmap_checker/guard.c
@@ -13,103 +13,21 @@
 
 #define MAX_CALL_STACK_DEPTH 256
 
-// the label to jump to whenever a guard fails
-extern void restore_and_jmp(void);
-uint64_t addr = 0;
-uint64_t r[16];
+typedef struct CallStackState {
+    uint64_t *ret_addrs;
+    unw_word_t *bps;
+    unw_word_t **registers;
+    stack_map_record_t *records;
+    uint32_t depth;
+} call_stack_state_t;
 
-int get_direct_locations(stack_map_t *sm, uint64_t *bps, stack_map_record_t *recs,
-        uint32_t rec_count, uint64_t **direct_locs, unw_word_t **registers)
+call_stack_state_t* get_call_stack_state(unw_cursor_t cursor,
+                                         unw_context_t context)
 {
-    // Restore the stack
-    int num_locations = 0;
-    uint64_t new_size = 0;
-    // Each record corresponds to a stack frame.
-    for (int i = 0; i < rec_count; ++i) {
-        stack_map_record_t opt_rec = recs[i];
-        stack_map_record_t *unopt_rec =
-            stmap_get_map_record(sm, ~opt_rec.patchpoint_id);
-        new_size += opt_rec.num_locations * sizeof(uint64_t);
-        *direct_locs = (uint64_t *)realloc(*direct_locs, new_size);
-        // Populate the stack of the optimized function with the values the
-        // unoptimized function expects
-        for (int j = 0; j < unopt_rec->num_locations - 1; j += 2) {
-            location_type type = unopt_rec->locations[j].kind;
-            uint64_t opt_location_value =
-                stmap_get_location_value(sm, opt_rec.locations[j],
-                                         registers[i], (void *)bps[i]);
-
-            uint64_t loc_size =
-                stmap_get_location_value(sm, opt_rec.locations[j + 1],
-                                         registers[i], (void *)bps[i]);
-            if (type == DIRECT) {
-                printf("Direct\n");
-                printf("At index %d at depth %d saving %lu of size %d\n",
-                        num_locations, i, opt_location_value,
-                        loc_size);
-                memcpy(*direct_locs + num_locations, &opt_location_value,
-                       loc_size);
-
-                ++num_locations;
-                memcpy(*direct_locs + num_locations, &loc_size, sizeof(uint64_t));
-                ++num_locations;
-            } else if (type == REGISTER) {
-                memcpy(*direct_locs + num_locations, &opt_location_value,
-                       loc_size);
-                ++num_locations;
-                memcpy(*direct_locs + num_locations, &loc_size, sizeof(uint64_t));
-                ++num_locations;
-            } else if (type == INDIRECT) {
-                uint64_t unopt_addr = (uint64_t) bps[i] +
-                    unopt_rec->locations[j].offset;
-                errx(1, "Not implemented - indirect.\n");
-            } else if (type != CONSTANT && type != CONST_INDEX && type != REGISTER) {
-                errx(1, "Unknown record - %u. Exiting\n", type);
-            }
-        }
-    }
-    return num_locations;
-}
-
-void __guard_failure(int64_t sm_id)
-{
-    // save register the state in global array r
-    asm volatile("mov %%rax,%0\n"
-                 "mov %%rcx,%1\n"
-                 "mov %%rdx,%2\n"
-                 "mov %%rbx,%3\n"
-                 "mov %%rsp,%4\n"
-                 "mov %%rbp,%5\n"
-                 "mov %%rsi,%6\n"
-                 "mov %%rdi,%7\n" : "=m"(r[0]), "=m"(r[1]), "=m"(r[2]),
-                                    "=m"(r[3]), "=m"(r[4]), "=m"(r[5]),
-                                    "=m"(r[6]), "=m"(r[7]) : : );
-    asm volatile("mov %%r8,%0\n"
-                 "mov %%r9,%1\n"
-                 "mov %%r10,%2\n"
-                 "mov %%r11,%3\n"
-                 "mov %%r12,%4\n"
-                 "mov %%r13,%5\n"
-                 "mov %%r14,%6\n"
-                 "mov %%r15,%7\n" : "=m"(r[8]), "=m"(r[9]), "=m"(r[10]),
-                                    "=m"(r[11]), "=m"(r[12]), "=m"(r[13]),
-                                    "=m"(r[14]), "=m"(r[15]) : : );
-    printf("Guard %ld failed!\n", sm_id);
-
+    uint64_t *ret_addrs = calloc(MAX_CALL_STACK_DEPTH, sizeof(uint64_t));
+    unw_word_t *bps = calloc(MAX_CALL_STACK_DEPTH, sizeof(unw_word_t));
     unw_word_t **registers = calloc(MAX_CALL_STACK_DEPTH, sizeof(unw_word_t *));
-
-    unw_cursor_t cursor;
-    unw_context_t context;
-    unw_getcontext(&context);
-    unw_init_local(&cursor, &context);
-
-    unw_cursor_t saved_cursor = cursor;
-    unw_word_t stack_ptr;
-    unw_word_t base_ptr;
-    // XXX
-    uint64_t **ret_addrs = calloc(MAX_CALL_STACK_DEPTH, sizeof(uint64_t *));
-    uint64_t *bps = calloc(MAX_CALL_STACK_DEPTH, sizeof(uint64_t));
-    size_t frame = 0;
+    uint32_t frame = 0;
     while (unw_step(&cursor) > 0) {
         unw_word_t off, pc;
         unw_get_reg(&cursor, UNW_REG_IP, &pc);
@@ -120,7 +38,6 @@ void __guard_failure(int64_t sm_id)
             // 16 registers are saved for each frame
             registers[frame] = calloc(16, sizeof(unw_word_t));
         }
-
         unw_get_reg(&cursor, UNW_X86_64_RAX, &registers[frame][0]);
         unw_get_reg(&cursor, UNW_X86_64_RDX, &registers[frame][1]);
         unw_get_reg(&cursor, UNW_X86_64_RCX, &registers[frame][2]);
@@ -137,69 +54,225 @@ void __guard_failure(int64_t sm_id)
         unw_get_reg(&cursor, UNW_X86_64_R13, &registers[frame][13]);
         unw_get_reg(&cursor, UNW_X86_64_R14, &registers[frame][14]);
         unw_get_reg(&cursor, UNW_X86_64_R15, &registers[frame][15]);
-        unw_get_reg(&cursor, UNW_REG_SP,     &stack_ptr);
-
 
         // Find base pointer of each function.
         char fun_name[128];
         unw_get_proc_name(&cursor, fun_name, sizeof(fun_name), &off);
+        printf("Found ret addr %p\n",
+            *(uint64_t *)((char *)registers[frame][6] + 8));
         ret_addrs[frame] =
-            (uint64_t *)((char *)registers[frame][6] + 8);
-        if (unw_get_reg(&cursor, UNW_TDEP_BP, &base_ptr)) {
-            printf("bp not found\n");
-        }
-        *(bps + frame) = base_ptr;
+            (uint64_t)((char *)registers[frame][UNW_X86_64_RBP] + 8);
+        *(bps + frame) = registers[frame][UNW_X86_64_RBP];
         frame++;
         if (!strcmp(fun_name, "main")) {
             --frame;
+            free (registers[frame]);
             break;
         }
     }
 
-    void *stack_map_addr = get_addr(".llvm_stackmaps");
-    if (!stack_map_addr) {
-        errx(1, ".llvm_stackmaps section not found. Exiting.\n");
+    call_stack_state_t *state = malloc(sizeof(call_stack_state_t));
+    state->ret_addrs = ret_addrs;
+    state->bps = bps;
+    state->registers = registers;
+    state->depth = frame;
+    state->records = NULL;
+    return state;
+}
+
+void free_call_stack_state(call_stack_state_t *state)
+{
+    for(int frame = 0; frame < state->depth; ++frame) {
+        free(state->registers[frame]);
     }
-    stack_map_t *sm = stmap_create(stack_map_addr);
+    free(state->ret_addrs);
+    free(state->registers);
+    free(state->bps);
+    free(state->records);
+    free(state);
+}
 
-    // Overwrite the old return addresses
-    size_t call_stack_depth = frame > 0 ? frame - 1 : 0;
+// the label to jump to whenever a guard fails
+extern void restore_and_jmp(void);
+uint64_t addr = 0;
 
+int get_direct_locations(stack_map_t *sm, call_stack_state_t *state,
+        uint64_t **direct_locs)
+{
+    int num_locations = 0;
+    uint64_t new_size = 0;
+    // Each record corresponds to a stack frame.
+    for (int i = 0; i < state->depth; ++i) {
+        stack_map_record_t opt_rec = state->records[i];
+        stack_map_record_t *unopt_rec =
+            stmap_get_map_record(sm, ~opt_rec.patchpoint_id);
+        new_size += opt_rec.num_locations * sizeof(uint64_t);
+        *direct_locs = (uint64_t *)realloc(*direct_locs, new_size);
+        // Populate the stack of the optimized function with the values the
+        // unoptimized function expects
+        for (int j = 0; j < unopt_rec->num_locations - 1; j += 2) {
+            location_type type = unopt_rec->locations[j].kind;
+            uint64_t opt_location_value =
+                stmap_get_location_value(sm, opt_rec.locations[j],
+                                         state->registers[i],
+                                         (void *)state->bps[i]);
+
+            uint64_t loc_size =
+                stmap_get_location_value(sm, opt_rec.locations[j + 1],
+                                         state->registers[i],
+                                         (void *)state->bps[i]);
+            if (type == DIRECT) {
+                printf("Direct\n");
+                memcpy(*direct_locs + num_locations, &opt_location_value,
+                       loc_size);
+                ++num_locations;
+                memcpy(*direct_locs + num_locations, &loc_size, sizeof(uint64_t));
+                ++num_locations;
+            } else if (type == REGISTER) {
+                memcpy(*direct_locs + num_locations, &opt_location_value,
+                       loc_size);
+                ++num_locations;
+                memcpy(*direct_locs + num_locations, &loc_size, sizeof(uint64_t));
+                ++num_locations;
+            } else if (type == INDIRECT) {
+                uint64_t unopt_addr = (uint64_t)state->bps[i] +
+                    unopt_rec->locations[j].offset;
+                errx(1, "Not implemented - indirect.\n");
+            } else if (type != CONSTANT && type != CONST_INDEX && type != REGISTER) {
+                errx(1, "Unknown record - %u. Exiting\n", type);
+            }
+        }
+    }
+    return num_locations;
+}
+
+void print_registers(size_t frame, unw_word_t **registers)
+{
+    printf("Registers in frame %d\n", frame);
+    printf("\tRAX: %lu\n", registers[frame][UNW_X86_64_RAX]);
+    printf("\tRCX: %lu\n", registers[frame][UNW_X86_64_RCX]);
+    printf("\tRDX: %lu\n", registers[frame][UNW_X86_64_RDX]);
+    printf("\tRBX: %lu\n", registers[frame][UNW_X86_64_RBX]);
+    printf("\tRSP: %lu\n", registers[frame][UNW_X86_64_RSP]);
+    printf("\tRBP: %lu\n", registers[frame][UNW_X86_64_RBP]);
+    printf("\tRSI: %lu\n", registers[frame][UNW_X86_64_RSI]);
+    printf("\tRDI: %lu\n", registers[frame][UNW_X86_64_RDI]);
+    printf("\tR8: %lu\n", registers[frame][UNW_X86_64_R8]);
+    printf("\tR9: %lu\n", registers[frame][UNW_X86_64_R9]);
+    printf("\tR10: %lu\n", registers[frame][UNW_X86_64_R10]);
+    printf("\tR11: %lu\n", registers[frame][UNW_X86_64_R11]);
+    printf("\tR12: %lu\n", registers[frame][UNW_X86_64_R12]);
+    printf("\tR13: %lu\n", registers[frame][UNW_X86_64_R13]);
+    printf("\tR14: %lu\n", registers[frame][UNW_X86_64_R14]);
+    printf("\tR15: %lu\n", registers[frame][UNW_X86_64_R15]);
+}
+
+void print_return_addrs(uint64_t **ret_addrs, size_t call_stack_depth)
+{
+    for (int frame = 0; frame < call_stack_depth; ++frame) {
+        printf("* Ret addr %p @ %p\n", (void *)*(uint64_t *)ret_addrs[frame],
+                ret_addrs[frame]);
+    }
+}
+
+void restore_unopt_stack(stack_map_t *sm, call_stack_state_t *state,
+                         stack_map_record_t *unopt_rec,
+                         stack_map_record_t *opt_rec)
+{
     // Need call_stack_depth + 1 stack maps (1 = the patchpoint which failed);
     // This stores the stack map records of the unoptimized trace
-    stack_map_record_t *unopt_call_stk_records = calloc(call_stack_depth + 1,
+    stack_map_record_t *unopt_call_stk_records = calloc(state->depth,
                                                   sizeof(stack_map_record_t));
 
-    stack_map_record_t *opt_call_stk_records = calloc(call_stack_depth + 1,
-                                                  sizeof(stack_map_record_t));
-    stack_map_record_t *unopt_rec = stmap_get_map_record(sm, ~sm_id);
-    stack_map_record_t *opt_rec = stmap_get_map_record(sm, sm_id);
+    state->records = calloc(state->depth, sizeof(stack_map_record_t));
 
-    if (!unopt_rec || !opt_rec) {
-        errx(1, "Stack map record not found. Exiting.\n");
-    }
 
     // Overwrite the old return addresses and store the stack map records
     // that correspond to each call which generated this stack trace in
     // unopt_call_stk_records.
     unopt_call_stk_records[0] = *unopt_rec;
-    opt_call_stk_records[0] = *opt_rec;
-    for (int i = 0; i < call_stack_depth; ++i) {
+    state->records[0] = *opt_rec;
+    stmap_print_map_record(sm, opt_rec->index, state->registers[0],
+                           (void *)state->bps[0]);
+    // Loop depth - 1 times, because the return address of 'trace'
+    // should not be overwritten (it should still return in main)
+    for (int i = 0; i < state->depth - 1; ++i) {
         stack_map_pos_t *sm_pos =
-            stmap_get_unopt_return_addr(sm, *(uint64_t *)ret_addrs[i]);
+            stmap_get_unopt_return_addr(sm, *(uint64_t *)state->ret_addrs[i]);
         uint64_t unopt_ret_addr =
             sm->stk_size_records[sm_pos->stk_size_record_index].fun_addr +
             sm->stk_map_records[sm_pos->stk_map_record_index].instr_offset;
-        *ret_addrs[i] = unopt_ret_addr;
+        // Overwrite the old return addresses
+        *(uint64_t *)state->ret_addrs[i] = unopt_ret_addr;
         stack_map_record_t *opt_stk_map_rec =
             stmap_get_map_record(
                 sm,
                 ~sm->stk_map_records[sm_pos->stk_map_record_index].patchpoint_id);
         unopt_call_stk_records[i + 1] =
             sm->stk_map_records[sm_pos->stk_map_record_index];
-        opt_call_stk_records[i + 1] = *opt_stk_map_rec;
+
+        state->records[i + 1] = *opt_stk_map_rec;
+        free(sm_pos);
     }
 
+    uint64_t *direct_locations = NULL;
+    int num_locations = get_direct_locations(sm, state, &direct_locations);
+
+    int loc_index = 0;
+    // Restore all the stacks on the call stack
+    for (int frame = 0; frame < state->depth; ++frame) {
+        stack_map_record_t unopt_rec = unopt_call_stk_records[frame];
+
+        stmap_print_map_record(sm, unopt_rec.index,
+                               state->registers[frame],
+                               (void *)state->bps[frame]);
+        // Populate the stack of the optimized function with the values the
+        // unoptimized function expects
+        for (int j = 0; j < unopt_rec.num_locations - 1; j += 2) {
+            location_type type = unopt_rec.locations[j].kind;
+            uint64_t opt_location_value = direct_locations[loc_index];
+            uint64_t loc_size = direct_locations[loc_index + 1];
+            if (type == DIRECT) {
+                uint64_t unopt_addr = (uint64_t)state->bps[frame] +
+                    unopt_rec.locations[j].offset;
+                memcpy((void *)unopt_addr, &opt_location_value,
+                        loc_size);
+                loc_index += 2;
+            } else if (type == REGISTER) {
+                uint64_t reg_num = unopt_rec.locations[j].dwarf_reg_num;
+                memcpy(state->registers[frame] + reg_num,
+                       &opt_location_value, loc_size);
+                loc_index += 2;
+            }
+        }
+    }
+    free(direct_locations);
+    free(unopt_call_stk_records);
+}
+
+void __guard_failure(int64_t sm_id)
+{
+    printf("Guard %ld failed!\n", sm_id);
+
+    unw_cursor_t cursor;
+    unw_context_t context;
+    unw_getcontext(&context);
+    unw_init_local(&cursor, &context);
+    unw_cursor_t saved_cursor = cursor;
+
+    call_stack_state_t *state = get_call_stack_state(cursor, context);
+
+    void *stack_map_addr = get_addr(".llvm_stackmaps");
+    if (!stack_map_addr) {
+        errx(1, ".llvm_stackmaps section not found. Exiting.\n");
+    }
+    stack_map_t *sm = stmap_create(stack_map_addr);
+    stack_map_record_t *unopt_rec = stmap_get_map_record(sm, ~sm_id);
+    stack_map_record_t *opt_rec = stmap_get_map_record(sm, sm_id);
+
+    if (!unopt_rec || !opt_rec) {
+        errx(1, "Stack map record not found. Exiting.\n");
+    }
     stack_size_record_t *unopt_size_rec =
         stmap_get_size_record(sm, unopt_rec->index);
     stack_size_record_t *opt_size_rec =
@@ -214,48 +287,17 @@ void __guard_failure(int64_t sm_id)
     if (callback_ret_addr >= opt_size_rec->fun_addr &&
         callback_ret_addr < (uint64_t)end_addr) {
         printf("A guard failed, but not in an inlined func\n");
+
     } else {
         printf("A guard failed in an inlined function.\n");
+        exit(1);
     }
-    uint64_t *direct_locations = NULL;
-    int num_locations = get_direct_locations(sm, bps, opt_call_stk_records,
-                                             call_stack_depth + 1,
-                                             &direct_locations,
-                                             registers);
+    restore_unopt_stack(sm, state, unopt_rec, opt_rec);
 
-    int loc_index = 0;
-
-    for (int frame = 0; frame < call_stack_depth; ++frame) {
-        printf("BP %p\n", bps[frame]);
-    }
-    // Restore all the stacks on the call stack
-    for (int frame = 0; frame < call_stack_depth + 1; ++frame) {
-        stack_map_record_t unopt_rec = unopt_call_stk_records[frame];
-
-        stmap_print_map_record(sm, unopt_rec.index,
-                               registers[frame], (void *)bps[frame]);
-        // Populate the stack of the optimized function with the values the
-        // unoptimized function expects
-        for (int j = 0; j < unopt_rec.num_locations - 1; j += 2) {
-            location_type type = unopt_rec.locations[j].kind;
-            uint64_t opt_location_value = direct_locations[loc_index];
-            uint64_t loc_size = direct_locations[loc_index + 1];
-            if (type == DIRECT) {
-                uint64_t unopt_addr = (uint64_t)bps[frame] +
-                    unopt_rec.locations[j].offset;
-                memcpy((void *)unopt_addr, &opt_location_value,
-                        loc_size);
-                loc_index += 2;
-            } else if (type == REGISTER) {
-                uint64_t reg_num = unopt_rec.locations[j].dwarf_reg_num;
-                memcpy(registers[frame] + reg_num, &opt_location_value, loc_size);
-                loc_index += 2;
-            }
-        }
-    }
     // The address to jump to
     addr = unopt_size_rec->fun_addr + unopt_rec->instr_offset;
-    frame = 0;
+
+    uint32_t frame = 0;
     while (unw_step(&saved_cursor) > 0) {
         unw_word_t off, pc;
         if (!pc) {
@@ -263,15 +305,13 @@ void __guard_failure(int64_t sm_id)
         }
         for (int i = 0; i < 16; ++i) {
             if (i != UNW_X86_64_RSP && i != UNW_X86_64_RBP) {
-                unw_set_reg(&cursor, i, registers[frame][i]);
+                unw_set_reg(&cursor, i, state->registers[frame][i]);
             }
         }
         ++frame;
     }
     stmap_free(sm);
-    free(direct_locations);
-    free(ret_addrs);
-    free(bps);
+    free_call_stack_state(state);
     asm volatile("jmp restore_and_jmp");
 }
 

--- a/src/stackmap_checker/guard.c
+++ b/src/stackmap_checker/guard.c
@@ -1,0 +1,153 @@
+#define UNW_LOCAL_ONLY
+
+#include <stdint.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <err.h>
+#include <signal.h>
+#include <libunwind.h>
+#include "stmap.h"
+#include "utils.h"
+
+#define MAX_CALL_STACK_DEPTH 256
+
+// the label to jump to whenever a guard fails
+extern void restore_and_jmp(void);
+uint64_t addr = 0;
+uint64_t r[16];
+
+void __guard_failure(int64_t sm_id)
+{
+    // save register the state in global array r
+    asm volatile("mov %%rax,%0\n"
+                 "mov %%rcx,%1\n"
+                 "mov %%rdx,%2\n"
+                 "mov %%rbx,%3\n"
+                 "mov %%rsp,%4\n"
+                 "mov %%rbp,%5\n"
+                 "mov %%rsi,%6\n"
+                 "mov %%rdi,%7\n" : "=m"(r[0]), "=m"(r[1]), "=m"(r[2]),
+                                    "=m"(r[3]), "=m"(r[4]), "=m"(r[5]),
+                                    "=m"(r[6]), "=m"(r[7]) : : );
+    asm volatile("mov %%r8,%0\n"
+                 "mov %%r9,%1\n"
+                 "mov %%r10,%2\n"
+                 "mov %%r11,%3\n"
+                 "mov %%r12,%4\n"
+                 "mov %%r13,%5\n"
+                 "mov %%r14,%6\n"
+                 "mov %%r15,%7\n" : "=m"(r[8]), "=m"(r[9]), "=m"(r[10]),
+                                    "=m"(r[11]), "=m"(r[12]), "=m"(r[13]),
+                                    "=m"(r[14]), "=m"(r[15]) : : );
+    printf("Guard %ld failed!\n", sm_id);
+
+    unw_cursor_t cursor;
+    unw_context_t context;
+    unw_getcontext(&context);
+    unw_init_local(&cursor, &context);
+    unw_word_t stack_ptr;
+
+    // XXX
+    uint64_t **ret_addrs = malloc(MAX_CALL_STACK_DEPTH * sizeof(uint64_t *));
+    size_t idx = 0;
+    while (unw_step(&cursor) > 0) {
+        unw_word_t off, pc;
+        unw_get_reg(&cursor, UNW_REG_IP, &pc);
+        if (!pc) {
+            break;
+        }
+        unw_get_reg(&cursor, UNW_REG_SP, &stack_ptr);
+
+        // 1. find base pointer of each function
+        // 2. replace return addresses with addresses from unopt
+        // 3. Restore all the stacks in the call stack
+        char fun_name[128];
+        int ret = !unw_get_proc_name(&cursor, fun_name, sizeof(fun_name), &off);
+
+        if (idx > 0) {
+            ret_addrs[idx - 1] = (uint64_t *)((char *)stack_ptr - 8);
+        }
+        idx++;
+
+        if (!strcmp(fun_name, "main")) {
+            break;
+        }
+    }
+    size_t call_stack_depth = idx > 0 ? idx - 1 : 0;
+    void *stack_map_addr = get_addr(".llvm_stackmaps");
+    if (!stack_map_addr) {
+        errx(1, ".llvm_stackmaps section not found. Exiting.\n");
+    }
+
+    stack_map_t *sm = stmap_create(stack_map_addr);
+    for (int i = 0; i < call_stack_depth; ++i) {
+        printf("* Ret addr %p\n", *(uint64_t *)ret_addrs[i]);
+        uint64_t unopt_ret_addr =
+            stmap_get_unopt_return_addr(sm, *ret_addrs[i]);
+        printf("Using %p instead\n", unopt_ret_addr);
+        *ret_addrs[i] = unopt_ret_addr;
+    }
+    return ;
+    void *bp = __builtin_frame_address(1);
+
+    int unopt_rec_idx = stmap_get_map_record(sm, ~sm_id);
+    int opt_rec_idx = stmap_get_map_record(sm, sm_id);
+
+    if (unopt_rec_idx == -1 || opt_rec_idx == -1) {
+        errx(1, "Stack map record not found. Exiting.\n");
+    }
+
+
+    stack_map_record_t unopt_rec = sm->stk_map_records[unopt_rec_idx];
+    stack_map_record_t opt_rec = sm->stk_map_records[opt_rec_idx];
+
+    stack_size_record_t unopt_size_rec =
+        sm->stk_size_records[stmap_get_size_record(sm, unopt_rec_idx)];
+
+    stack_size_record_t opt_size_rec =
+        sm->stk_size_records[stmap_get_size_record(sm, opt_rec_idx)];
+
+    // Restore the stack
+    uint64_t *direct_locations =
+        (uint64_t *)malloc(sizeof(uint64_t) * unopt_rec.num_locations);
+    // Populate the stack of the optimized function with the values the
+    // unoptimized function expects
+    for (int i = 1; i < unopt_rec.num_locations - 1; i += 2) {
+        location_type type = unopt_rec.locations[i].kind;
+        uint64_t opt_location_value =
+            stmap_get_location_value(sm, opt_rec.locations[i], r, bp);
+        if (type == REGISTER) {
+            uint16_t reg_num = unopt_rec.locations[i].dwarf_reg_num;
+            uint64_t loc_size =
+                stmap_get_location_value(sm, opt_rec.locations[i + 1], r, bp);
+            memcpy(r + reg_num, &opt_location_value, loc_size);
+        } else if (type == DIRECT) {
+            uint64_t loc_size =
+                stmap_get_location_value(sm, opt_rec.locations[i + 1], r, bp);
+            memcpy(direct_locations + i, &opt_location_value,
+                    loc_size);
+        } else if (type == INDIRECT) {
+            uint64_t unopt_addr = (uint64_t) bp + unopt_rec.locations[i].offset;
+            errx(1, "Not implemented - indirect.\n");
+        } else if (type != CONSTANT && type != CONST_INDEX) {
+            errx(1, "Unknown record - %u. Exiting\n", type);
+        }
+    }
+
+    for (int i = 1; i < unopt_rec.num_locations - 1; i += 2) {
+        location_type type = unopt_rec.locations[i].kind;
+        if (type == DIRECT) {
+            uint64_t unopt_addr = (uint64_t)bp + unopt_rec.locations[i].offset;
+            uint64_t loc_size =
+                stmap_get_location_value(sm, opt_rec.locations[i + 1], r, bp);
+            memcpy((void *)unopt_addr, direct_locations + i, loc_size);
+        }
+    }
+    addr = unopt_size_rec.fun_addr + unopt_rec.instr_offset;
+    stmap_free(sm);
+    free(direct_locations);
+    asm volatile("jmp restore_and_jmp");
+}
+

--- a/src/stackmap_checker/jump.s
+++ b/src/stackmap_checker/jump.s
@@ -2,20 +2,6 @@
 
 # Restores the register state stored in array r and jumps to addr
 restore_and_jmp:
-    mov    r,%rax
-    mov    r+0x8,%rcx
-    mov    r+0x10,%rdx
-    mov    r+0x18,%rbx
-    mov    r+0x30,%rsi
-    mov    r+0x38,%rdi
-    mov    r+0x40,%r8
-    mov    r+0x48,%r9
-    mov    r+0x50,%r10
-    mov    r+0x58,%r11
-    mov    r+0x60,%r12
-    mov    r+0x68,%r13
-    mov    r+0x70,%r14
-    mov    r+0x78,%r15
     mov    %rbp, %rsp
     pop    %rbp
     pop    %rax # pop the return address of __guard_failure

--- a/src/stackmap_checker/jump.s
+++ b/src/stackmap_checker/jump.s
@@ -16,5 +16,7 @@ restore_and_jmp:
     mov    r+0x68,%r13
     mov    r+0x70,%r14
     mov    r+0x78,%r15
-    push   %rbp
-    jmp   *addr
+    mov    %rbp, %rsp
+    pop    %rbp
+    pop    %rax # pop the return address of __guard_failure
+    jmp    *addr

--- a/src/stackmap_checker/jump.s
+++ b/src/stackmap_checker/jump.s
@@ -16,7 +16,7 @@ restore_and_jmp:
     mov    r+0x68,%r13
     mov    r+0x70,%r14
     mov    r+0x78,%r15
-    mov    %rbp,%rsp
-    pop    %rbp
-    pop    %rax # pop the return address
-    jmp    *addr
+    push   fun_ret_addr
+    push   %rbp
+    mov    %rsp, %rbp
+    jmp   *addr

--- a/src/stackmap_checker/jump.s
+++ b/src/stackmap_checker/jump.s
@@ -16,7 +16,5 @@ restore_and_jmp:
     mov    r+0x68,%r13
     mov    r+0x70,%r14
     mov    r+0x78,%r15
-    push   fun_ret_addr
     push   %rbp
-    mov    %rsp, %rbp
     jmp   *addr

--- a/src/stackmap_checker/stmap.c
+++ b/src/stackmap_checker/stmap.c
@@ -157,16 +157,17 @@ stack_map_pos_t* stmap_get_unopt_return_addr(stack_map_t *sm, uint64_t return_ad
         stmap_get_map_record(sm, ~call_rec->patchpoint_id);
 
     if (!unopt_call_rec) {
-        errx(1, "Unoptimized call record not found. Exiting.\n");
+        errx(1, "(Unopt) map record not found (PPID = %d). Exiting.\n",
+             ~call_rec->patchpoint_id);
     }
     stack_size_record_t *stk_size_rec =
         stmap_get_size_record(sm, unopt_call_rec->index);
     if (!stk_size_rec) {
-        errx(1, "Unoptimized call record not found. Exiting.\n");
+        errx(1, "(Unopt) size record not found. Exiting.\n");
     }
     stack_map_pos_t *sm_pos = malloc(sizeof(stack_map_pos_t));
-    sm_pos->stk_size_record_index = unopt_call_rec->index;
-    sm_pos->stk_map_record_index = stk_size_rec->index;
+    sm_pos->stk_map_record_index = unopt_call_rec->index;
+    sm_pos->stk_size_record_index = stk_size_rec->index;
     return sm_pos;
 }
 

--- a/src/stackmap_checker/stmap.c
+++ b/src/stackmap_checker/stmap.c
@@ -16,16 +16,21 @@ stack_map_t* stmap_create(uint8_t *start_addr)
     sm->stk_size_records = (stack_size_record_t *)calloc(
             sm->num_func,
             sizeof(stack_size_record_t));
-    memcpy(sm->stk_size_records, addr,
-           sm->num_func * sizeof(stack_size_record_t));
-    addr += sm->num_func * sizeof(stack_size_record_t);
-    sm->constants = (uint64_t *)calloc(sm->num_const, sizeof(uint64_t));
+    for (size_t i = 0; i < sm->num_func; ++i) {
+        memcpy(sm->stk_size_records + i, addr,
+               sizeof(stack_size_record_t) - sizeof(uint64_t));
+        sm->stk_size_records[i].index = i;
+        // Need to subtract the size of index (it is not part of the actual SM)
+        addr += sizeof(stack_size_record_t) - sizeof(uint64_t);
+    }
+    sm->constants = (uint64_t *)malloc(sizeof(uint64_t) * sm->num_const);
     memcpy(sm->constants, addr, sm->num_const * sizeof(uint64_t));
     addr += sizeof(uint64_t) * sm->num_const;
     sm->stk_map_records = (stack_map_record_t *)calloc(
             sm->num_rec, sizeof(stack_map_record_t));
     size_t rec_header_size = sizeof(uint64_t) + sizeof(uint32_t)
         + 2 * sizeof(uint16_t);
+
     for (size_t i = 0; i < sm->num_rec; ++i) {
         stack_map_record_t *rec = sm->stk_map_records + i;
         // copy the first 4 fields
@@ -36,34 +41,36 @@ stack_map_t* stmap_create(uint8_t *start_addr)
         memcpy(rec->locations, addr, rec->num_locations * sizeof(location_t));
         addr += rec->num_locations * sizeof(location_t);
         // padding to align on 8-byte boundary
-        printf("Num loc %lu sizeof loc %d\n", rec->num_locations,
-                sizeof(location_t));
         if ((rec->num_locations * sizeof(location_t)) % 8) {
             addr += sizeof(uint32_t);
         }
+
         addr += sizeof(uint16_t); // padding
         memcpy(&rec->num_liveouts, addr, sizeof(uint16_t));
         addr += sizeof(uint16_t);
         rec->liveouts = (liveout_t *)calloc(rec->num_liveouts,
                                             sizeof(liveout_t));
         memcpy(rec->liveouts, addr, sizeof(liveout_t) * rec->num_liveouts);
+
         addr += sizeof(liveout_t) * rec->num_liveouts;
         // padding to align on 8-byte boundary
         if ((2 * sizeof(uint16_t) + sizeof(liveout_t) * rec->num_liveouts) % 8) {
             addr += sizeof(uint32_t);
         }
+
+        rec->index = i;
     }
     return sm;
 }
 
-int stmap_get_map_record(stack_map_t *sm, uint64_t patchpoint_id)
+stack_map_record_t* stmap_get_map_record(stack_map_t *sm, uint64_t patchpoint_id)
 {
     for (size_t i = 0; i < sm->num_rec; ++i) {
         if (sm->stk_map_records[i].patchpoint_id == patchpoint_id) {
-            return i;
+            return &sm->stk_map_records[i];
         }
     }
-    return -1;
+    return NULL;
 }
 
 uint64_t stmap_get_location_value(stack_map_t *sm, location_t loc,
@@ -98,7 +105,7 @@ uint64_t stmap_get_location_value(stack_map_t *sm, location_t loc,
     return 0;
 }
 
-int stmap_get_size_record(stack_map_t *sm, uint64_t sm_rec_idx)
+stack_size_record_t* stmap_get_size_record(stack_map_t *sm, uint64_t sm_rec_idx)
 {
     size_t record_count = 1;
     // Each function contains a number of stackmap calls. This works out which
@@ -108,13 +115,13 @@ int stmap_get_size_record(stack_map_t *sm, uint64_t sm_rec_idx)
     for (size_t i = 0; i < sm->num_func; ++i) {
         stack_size_record_t rec = sm->stk_size_records[i];
         if (sm_rec_idx + 1 >= record_count &&
-                sm_rec_idx + 1 < record_count + rec.record_count) {
-            return i;
+            sm_rec_idx + 1 < record_count + sm->stk_size_records[i].record_count) {
+            return &sm->stk_size_records[i];
         } else {
             record_count += rec.record_count;
         }
     }
-    return -1;
+    return NULL;
 }
 
 int stmap_get_last_record(stack_map_t *sm, int target_size_rec_idx)
@@ -123,15 +130,14 @@ int stmap_get_last_record(stack_map_t *sm, int target_size_rec_idx)
     uint64_t max_addr = 0;
     for (size_t i = 0; i < sm->num_rec; ++i) {
         stack_map_record_t rec = sm->stk_map_records[i];
-        int size_rec_idx = stmap_get_size_record(sm, i);
-        if (size_rec_idx != target_size_rec_idx) {
-            continue;
-        }
-        if (size_rec_idx == -1) {
+        stack_size_record_t *size_rec = stmap_get_size_record(sm, i);
+        if (!size_rec) {
             return -1;
         }
-        uint64_t addr =
-            sm->stk_size_records[size_rec_idx].fun_addr + rec.instr_offset;
+        if (size_rec->index != target_size_rec_idx) {
+            continue;
+        }
+        uint64_t addr = size_rec->fun_addr + rec.instr_offset;
         if (addr > max_addr) {
             max_addr = addr;
             map_idx = i;
@@ -140,47 +146,81 @@ int stmap_get_last_record(stack_map_t *sm, int target_size_rec_idx)
     return map_idx;
 }
 
-uint64_t stmap_get_unopt_return_addr(stack_map_t *sm, uint64_t return_addr)
+stack_map_pos_t* stmap_get_unopt_return_addr(stack_map_t *sm, uint64_t return_addr)
 {
-    int call_rec_idx =
+    stack_map_record_t* call_rec =
         stmap_first_rec_after_addr(sm, return_addr);
-    if (call_rec_idx == -1) {
+    if (!call_rec) {
         errx(1, "Call record not found. Exiting.\n");
     }
-    int unopt_call_rec_idx =
-        stmap_get_map_record(sm,
-                             ~sm->stk_map_records[call_rec_idx].patchpoint_id);
+    stack_map_record_t *unopt_call_rec =
+        stmap_get_map_record(sm, ~call_rec->patchpoint_id);
 
-    if (unopt_call_rec_idx == -1) {
+    if (!unopt_call_rec) {
         errx(1, "Unoptimized call record not found. Exiting.\n");
     }
-    int stk_size_idx = stmap_get_size_record(sm, unopt_call_rec_idx);
-    return sm->stk_map_records[unopt_call_rec_idx].instr_offset +
-        sm->stk_size_records[stk_size_idx].fun_addr;
+    stack_size_record_t *stk_size_rec =
+        stmap_get_size_record(sm, unopt_call_rec->index);
+    if (!stk_size_rec) {
+        errx(1, "Unoptimized call record not found. Exiting.\n");
+    }
+    stack_map_pos_t *sm_pos = malloc(sizeof(stack_map_pos_t));
+    sm_pos->stk_size_record_index = unopt_call_rec->index;
+    sm_pos->stk_map_record_index = stk_size_rec->index;
+    return sm_pos;
 }
 
-int stmap_first_rec_after_addr(stack_map_t *sm, uint64_t addr)
+
+void stmap_print_stack_size_records(stack_map_t *sm)
+{
+    for (size_t i = 0; i < sm->num_func; ++i) {
+        stack_size_record_t rec = sm->stk_size_records[i];
+        printf("Addr %p size %lu\n", (void *)rec.fun_addr, rec.stack_size);
+    }
+}
+
+stack_map_record_t* stmap_first_rec_after_addr(stack_map_t *sm, uint64_t addr)
 {
     for (size_t i = 0; i < sm->num_rec; ++i) {
         stack_map_record_t rec = sm->stk_map_records[i];
-        int size_rec_idx = stmap_get_size_record(sm, i);
-        if (size_rec_idx == -1) {
+        stack_size_record_t *size_rec = stmap_get_size_record(sm, i);
+        if (!size_rec) {
             errx(1, "No stack map after call!. Exiting.\n");
         }
-        stack_size_record_t size_rec = sm->stk_size_records[size_rec_idx];
-        int last_rec_idx = stmap_get_last_record(sm, size_rec_idx);
-        uint64_t last_addr = size_rec.fun_addr +
+        int last_rec_idx = stmap_get_last_record(sm, size_rec->index);
+        uint64_t last_addr = size_rec->fun_addr +
             sm->stk_map_records[last_rec_idx].instr_offset;
+        printf("Looking for addr %p %lu\n", (void *)addr, addr);
+
+        printf("Checking range %p %p\n",
+                (void *) size_rec->fun_addr,
+                (void *)(size_rec->fun_addr + rec.instr_offset)
+                );
         if (addr > last_addr) {
             continue;
         }
 
-        if (size_rec.fun_addr + rec.instr_offset >= addr
-            && addr > size_rec.fun_addr) {
-            return i;
+        if (size_rec->fun_addr + rec.instr_offset >= addr
+            && addr > size_rec->fun_addr) {
+
+            printf("%lu > %lu == %d\n",
+                    size_rec->fun_addr + rec.instr_offset,
+                    addr,
+                    size_rec->fun_addr + rec.instr_offset >= addr
+                    );
+            // when a guard fails in trace, work out if it failed in the
+            // inlined get_number call or in trace
+            printf("Found record %lu after addr %p in fun %p %d\n",
+                    i,
+                    (void *)size_rec->fun_addr + rec.instr_offset,
+                    (void *)size_rec->fun_addr,
+                    (void *)size_rec->fun_addr + rec.instr_offset >= (void *)addr
+
+                    );
+            return &sm->stk_map_records[i];
         }
     }
-    return -1;
+    return NULL;
 }
 
 void stmap_print_map_record(stack_map_t *sm, uint32_t rec_idx,

--- a/src/stackmap_checker/stmap.c
+++ b/src/stackmap_checker/stmap.c
@@ -190,33 +190,14 @@ stack_map_record_t* stmap_first_rec_after_addr(stack_map_t *sm, uint64_t addr)
         int last_rec_idx = stmap_get_last_record(sm, size_rec->index);
         uint64_t last_addr = size_rec->fun_addr +
             sm->stk_map_records[last_rec_idx].instr_offset;
-        printf("Looking for addr %p %lu\n", (void *)addr, addr);
-
-        printf("Checking range %p %p\n",
-                (void *) size_rec->fun_addr,
-                (void *)(size_rec->fun_addr + rec.instr_offset)
-                );
         if (addr > last_addr) {
             continue;
         }
 
         if (size_rec->fun_addr + rec.instr_offset >= addr
             && addr > size_rec->fun_addr) {
-
-            printf("%lu > %lu == %d\n",
-                    size_rec->fun_addr + rec.instr_offset,
-                    addr,
-                    size_rec->fun_addr + rec.instr_offset >= addr
-                    );
             // when a guard fails in trace, work out if it failed in the
             // inlined get_number call or in trace
-            printf("Found record %lu after addr %p in fun %p %d\n",
-                    i,
-                    (void *)size_rec->fun_addr + rec.instr_offset,
-                    (void *)size_rec->fun_addr,
-                    (void *)size_rec->fun_addr + rec.instr_offset >= (void *)addr
-
-                    );
             return &sm->stk_map_records[i];
         }
     }

--- a/src/stackmap_checker/stmap.c
+++ b/src/stackmap_checker/stmap.c
@@ -157,9 +157,10 @@ stack_map_pos_t* stmap_get_unopt_return_addr(stack_map_t *sm, uint64_t return_ad
         stmap_get_map_record(sm, ~call_rec->patchpoint_id);
 
     if (!unopt_call_rec) {
-        errx(1, "(Unopt) map record not found (PPID = %d). Exiting.\n",
+        errx(1, "(Unopt) map record not found (PPID = %lu). Exiting.\n",
              ~call_rec->patchpoint_id);
     }
+
     stack_size_record_t *stk_size_rec =
         stmap_get_size_record(sm, unopt_call_rec->index);
     if (!stk_size_rec) {
@@ -176,7 +177,6 @@ void stmap_print_stack_size_records(stack_map_t *sm)
 {
     for (size_t i = 0; i < sm->num_func; ++i) {
         stack_size_record_t rec = sm->stk_size_records[i];
-        printf("Addr %p size %lu\n", (void *)rec.fun_addr, rec.stack_size);
     }
 }
 

--- a/src/stackmap_checker/stmap.h
+++ b/src/stackmap_checker/stmap.h
@@ -101,6 +101,8 @@ int stmap_get_size_record(stack_map_t *sm, uint64_t sm_rec_idx);
  */
 uint64_t stmap_get_location_value(stack_map_t *sm, location_t loc,
                                   uint64_t *regs, void *bp);
+
+int stmap_first_rec_after_addr(stack_map_t *sm, uint64_t addr);
 void stmap_print_stack_size_records(stack_map_t *);
 void stmap_print_map_record(stack_map_t *sm, uint32_t rec_idx,
                             uint64_t *regs, void *frame_addr);

--- a/src/stackmap_checker/stmap.h
+++ b/src/stackmap_checker/stmap.h
@@ -102,6 +102,7 @@ int stmap_get_size_record(stack_map_t *sm, uint64_t sm_rec_idx);
 uint64_t stmap_get_location_value(stack_map_t *sm, location_t loc,
                                   uint64_t *regs, void *bp);
 
+uint64_t stmap_get_unopt_return_addr(stack_map_t *sm, uint64_t return_addr);
 int stmap_first_rec_after_addr(stack_map_t *sm, uint64_t addr);
 void stmap_print_stack_size_records(stack_map_t *);
 void stmap_print_map_record(stack_map_t *sm, uint32_t rec_idx,

--- a/src/stackmap_checker/stmap.h
+++ b/src/stackmap_checker/stmap.h
@@ -71,6 +71,8 @@ typedef struct StackMap {
     stack_map_record_t *stk_map_records;
 } stack_map_t;
 
+// Identifies an address using a stack map record and a stack size record. This
+// is the address of a stackmap/patchpoint call.
 typedef struct StackMapPosition {
     uint32_t stk_size_record_index;
     uint32_t stk_map_record_index;
@@ -109,8 +111,25 @@ stack_size_record_t* stmap_get_size_record(stack_map_t *sm, uint64_t sm_rec_idx)
 uint64_t stmap_get_location_value(stack_map_t *sm, location_t loc,
                                   uint64_t *regs, void *bp);
 
+/*
+ * Return the stack map/size record pair which describes the return address in an
+ * unoptimized function which corresponds to `return_addr`.
+ *
+ * `return_addr` is expected to be the return address of an optimized function.
+ */
 stack_map_pos_t* stmap_get_unopt_return_addr(stack_map_t *sm, uint64_t return_addr);
+
+/*
+ * Return the first stack map record located at an address greater than `addr`.
+ */
 stack_map_record_t* stmap_first_rec_after_addr(stack_map_t *sm, uint64_t addr);
+
+/*
+ * Return the last stack map record associated with the specified stack size
+ * record.
+ */
+stack_map_record_t* stmap_get_last_record(stack_map_t *sm,
+                                          stack_size_record_t target_size_rec);
 void stmap_print_stack_size_records(stack_map_t *);
 void stmap_print_map_record(stack_map_t *sm, uint32_t rec_idx,
                             uint64_t *regs, void *frame_addr);

--- a/src/stackmap_checker/stmap.h
+++ b/src/stackmap_checker/stmap.h
@@ -45,6 +45,7 @@ typedef struct StackMapRecord {
     location_t *locations;
     uint16_t   num_liveouts;
     liveout_t  *liveouts;
+    uint64_t index;
 } stack_map_record_t;
 
 // A record which describes a function which contains a `stackmap` call.
@@ -52,6 +53,7 @@ typedef struct StackSizeRecord {
     uint64_t fun_addr;
     uint64_t stack_size;
     uint64_t record_count;
+    uint64_t index;
 } stack_size_record_t;
 
 typedef struct StackMap {
@@ -69,6 +71,11 @@ typedef struct StackMap {
     stack_map_record_t *stk_map_records;
 } stack_map_t;
 
+typedef struct StackMapPosition {
+    uint32_t stk_size_record_index;
+    uint32_t stk_map_record_index;
+} stack_map_pos_t;
+
 /*
  * Populate a StackMap with the information at the given address.
  *
@@ -84,7 +91,7 @@ void stmap_free(stack_map_t *sm);
 /*
  * Return the stack map record which corresponds to the specified patchpoint.
  */
-int stmap_get_map_record(stack_map_t *sm, uint64_t patchpoint_id);
+stack_map_record_t* stmap_get_map_record(stack_map_t *sm, uint64_t patchpoint_id);
 
 /*
  * Return the stack size record associated with the specified stack map record.
@@ -94,7 +101,7 @@ int stmap_get_map_record(stack_map_t *sm, uint64_t patchpoint_id);
  * This is used to associate each stackmap/patchpoint call with the function it
  * belongs to.
  */
-int stmap_get_size_record(stack_map_t *sm, uint64_t sm_rec_idx);
+stack_size_record_t* stmap_get_size_record(stack_map_t *sm, uint64_t sm_rec_idx);
 
 /*
  * Compute the value of the specified location.
@@ -102,8 +109,8 @@ int stmap_get_size_record(stack_map_t *sm, uint64_t sm_rec_idx);
 uint64_t stmap_get_location_value(stack_map_t *sm, location_t loc,
                                   uint64_t *regs, void *bp);
 
-uint64_t stmap_get_unopt_return_addr(stack_map_t *sm, uint64_t return_addr);
-int stmap_first_rec_after_addr(stack_map_t *sm, uint64_t addr);
+stack_map_pos_t* stmap_get_unopt_return_addr(stack_map_t *sm, uint64_t return_addr);
+stack_map_record_t* stmap_first_rec_after_addr(stack_map_t *sm, uint64_t addr);
 void stmap_print_stack_size_records(stack_map_t *);
 void stmap_print_map_record(stack_map_t *sm, uint32_t rec_idx,
                             uint64_t *regs, void *frame_addr);

--- a/src/stackmap_checker/trace.c
+++ b/src/stackmap_checker/trace.c
@@ -27,6 +27,7 @@ void trace()
 {
     char four = '4';
     int y = 155;
+    double k = 8.2345;
     int x = get_number(0);
     putchar(x +'0');
     putchar('\n');
@@ -34,6 +35,9 @@ void trace()
     putchar('\n');
 
     putchar(y % 10 + '0');
+    putchar('\n');
+
+    putchar((int)k + '0');
     putchar('\n');
 }
 

--- a/src/stackmap_checker/trace.c
+++ b/src/stackmap_checker/trace.c
@@ -6,16 +6,34 @@ int more_indirection()
     return 3;
 }
 
-int get_number()
+int get_number(int level)
 {
-    int x = more_indirection();
-    return x;
+    if (level < 2) {
+        putchar(level + '0');
+        putchar('\n');
+        return get_number(level + 1);
+    } else {
+        char one = '1';
+        char two = 2 + '0';
+        int x = more_indirection();
+        putchar(one);
+        putchar(two);
+        putchar('\n');
+        return x;
+    }
 }
 
 void trace()
 {
-    int x = get_number();
+    char four = '4';
+    int y = 155;
+    int x = get_number(0);
     putchar(x +'0');
+    putchar('\n');
+    putchar(four);
+    putchar('\n');
+
+    putchar(y % 10 + '0');
     putchar('\n');
 }
 

--- a/src/stackmap_checker/trace.c
+++ b/src/stackmap_checker/trace.c
@@ -1,154 +1,15 @@
-#include <stdint.h>
-#include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
-#include <err.h>
-#include "stmap.h"
-#include "utils.h"
 
-// the label to jump to whenever a guard fails
-extern void restore_and_jmp(void);
-
-// The address to jump to. This represents the address execution should resume
-// at.
-uint64_t addr = 0;
-
-// The saved registers.
-uint64_t r[16];
-uint64_t fun_ret_addr = 0;
-
-int get_number(void);
-void trace(void);
-
-/*
- * The guard failure handler.
- *
- * This is supposed to restore the stack/register state and resume execution in
- * the unoptimized version of the trace.
- */
-void __guard_failure(int64_t sm_id)
+int more_indirection()
 {
-    // Save register the state in global array r
-    asm volatile("mov %%rax,%0\n"
-                 "mov %%rcx,%1\n"
-                 "mov %%rdx,%2\n"
-                 "mov %%rbx,%3\n"
-                 "mov %%rsp,%4\n"
-                 "mov %%rbp,%5\n"
-                 "mov %%rsi,%6\n"
-                 "mov %%rdi,%7\n" : "=m"(r[0]), "=m"(r[1]), "=m"(r[2]),
-                                    "=m"(r[3]), "=m"(r[4]), "=m"(r[5]),
-                                    "=m"(r[6]), "=m"(r[7]) : : );
-    asm volatile("mov %%r8,%0\n"
-                 "mov %%r9,%1\n"
-                 "mov %%r10,%2\n"
-                 "mov %%r11,%3\n"
-                 "mov %%r12,%4\n"
-                 "mov %%r13,%5\n"
-                 "mov %%r14,%6\n"
-                 "mov %%r15,%7\n" : "=m"(r[8]), "=m"(r[9]), "=m"(r[10]),
-                                    "=m"(r[11]), "=m"(r[12]), "=m"(r[13]),
-                                    "=m"(r[14]), "=m"(r[15]) : : );
-    printf("Guard %ld failed!\n", sm_id);
-    void *stack_map_addr = get_addr(".llvm_stackmaps");
-    if (!stack_map_addr) {
-        errx(1, ".llvm_stackmaps section not found. Exiting.\n");
-    }
-
-    stack_map_t *sm = stmap_create(stack_map_addr);
-
-    // The frame address of `trace`.
-    void *bp = __builtin_frame_address(1);
-
-    // Retrieve the indices of the two stack map records which correspond to
-    // the point where a guard failed.
-    // unopt_rec_idx is the index of the stack map record of the unoptimized
-    // version of the function in which a guard failed
-    int unopt_rec_idx = stmap_get_map_record(sm, ~sm_id);
-    // The index of the record which corresponds to the patchpoint which
-    // called __guard_failure.
-    int opt_rec_idx = stmap_get_map_record(sm, sm_id);
-
-    if (unopt_rec_idx == -1 || opt_rec_idx == -1) {
-        errx(1, "Stack map record not found. Exiting.\n");
-    }
-
-
-    stack_map_record_t unopt_rec = sm->stk_map_records[unopt_rec_idx];
-    stack_map_record_t opt_rec = sm->stk_map_records[opt_rec_idx];
-
-    stack_size_record_t unopt_size_rec =
-        sm->stk_size_records[stmap_get_size_record(sm, unopt_rec_idx)];
-
-    stack_size_record_t opt_size_rec =
-        sm->stk_size_records[stmap_get_size_record(sm, opt_rec_idx)];
-
-    // get the end address of the function in which a guard failed
-    void *end_addr = get_sym_end((void *)opt_size_rec.fun_addr, "trace");
-    uint64_t callback_ret_addr = (uint64_t) __builtin_return_address(0);
-    if (callback_ret_addr >= opt_size_rec.fun_addr &&
-        callback_ret_addr < (uint64_t)end_addr) {
-        printf("A guard failed, but not in an inlined func\n");
-    } else {
-        printf("A guard failed in an inlined function.\n");
-    }
-
-    // Save the direct (stack) locations. These need to be restored later,
-    // because the process of restoring them might cause other values on the
-    // stack of `trace` to be overwritten.
-    uint64_t *direct_locations =
-        (uint64_t *)calloc(unopt_rec.num_locations, sizeof(uint64_t));
-    // Locations are considered in pairs,  which is why the loop counter is
-    // incremented by 2. This is because locations stored at odd indices
-    // represent the sizes of the other locations. This is important because
-    // the runtime needs to know how many bytes to copy from each location to
-    // restore the stack state.
-    for (int i = 1; i < unopt_rec.num_locations - 1; i += 2) {
-        location_type type = unopt_rec.locations[i].kind;
-        // Get the value of the current location. This value needs to be placed
-        // on the stack of the unoptimized function, or in a register.
-        uint64_t opt_location_value =
-            stmap_get_location_value(sm, opt_rec.locations[i], r, bp);
-        if (type == REGISTER) {
-            uint16_t reg_num = unopt_rec.locations[i].dwarf_reg_num;
-            uint64_t loc_size =
-                stmap_get_location_value(sm, opt_rec.locations[i + 1], r, bp);
-            memcpy(r + reg_num, &opt_location_value, loc_size);
-        } else if (type == DIRECT) {
-            uint64_t loc_size =
-                stmap_get_location_value(sm, opt_rec.locations[i + 1], r, bp);
-            memcpy(direct_locations + i, &opt_location_value,
-                    loc_size);
-        } else if (type == INDIRECT) {
-            uint64_t unopt_addr = (uint64_t) bp + unopt_rec.locations[i].offset;
-            errx(1, "Not implemented - indirect.\n");
-        } else if (type != CONSTANT && type != CONST_INDEX) {
-            errx(1, "Unknown record - %u. Exiting\n", type);
-        }
-    }
-
-    // Populate the stack of the optimized function with the values the
-    // unoptimized function expects.
-    for (int i = 1; i < unopt_rec.num_locations - 1; i += 2) {
-        location_type type = unopt_rec.locations[i].kind;
-        if (type == DIRECT) {
-            uint64_t unopt_addr = (uint64_t)bp + unopt_rec.locations[i].offset;
-            uint64_t loc_size =
-                stmap_get_location_value(sm, opt_rec.locations[i + 1], r, bp);
-            memcpy((void *)unopt_addr, direct_locations + i, loc_size);
-        }
-    }
-
-    addr = unopt_size_rec.fun_addr + unopt_rec.instr_offset;
-    stmap_free(sm);
-    free(direct_locations);
-    asm volatile("jmp restore_and_jmp");
+    return 3;
 }
 
 int get_number()
 {
-    return 3;
+    int x = more_indirection();
+    return x;
 }
 
 void trace()
@@ -156,7 +17,6 @@ void trace()
     int x = get_number();
     putchar(x +'0');
     putchar('\n');
-    exit(x);
 }
 
 int main(int argc, char **argv)

--- a/src/stackmap_checker/utils.c
+++ b/src/stackmap_checker/utils.c
@@ -5,9 +5,11 @@
 #include <fcntl.h>
 #include "utils.h"
 
+#define TRACE_BIN "trace"
+
 Elf64_Ehdr* get_elf_header(const char *section_name)
 {
-    int fd = open("trace", O_RDONLY);
+    int fd = open(TRACE_BIN, O_RDONLY);
     void *data = mmap(NULL,
                       lseek(fd, 0, SEEK_END), // file size
                       PROT_READ,

--- a/src/stackmap_checker/utils.c
+++ b/src/stackmap_checker/utils.c
@@ -5,7 +5,7 @@
 #include <fcntl.h>
 #include "utils.h"
 
-void *get_addr(const char *section_name)
+Elf64_Ehdr* get_elf_header(const char *section_name)
 {
     int fd = open("trace", O_RDONLY);
     void *data = mmap(NULL,
@@ -16,6 +16,14 @@ void *get_addr(const char *section_name)
     Elf64_Ehdr *elf = (Elf64_Ehdr *) data;
     Elf64_Shdr *shdr = (Elf64_Shdr *) ((char *)data + elf->e_shoff);
     char *strtab = (char *)data + shdr[elf->e_shstrndx].sh_offset;
+    return elf;
+}
+
+void* get_addr(const char *section_name)
+{
+    Elf64_Ehdr *elf = get_elf_header(section_name);
+    Elf64_Shdr *shdr = (Elf64_Shdr *) ((char *)elf + elf->e_shoff);
+    char *strtab = (char *)elf + shdr[elf->e_shstrndx].sh_offset;
     for(int i = 0; i < elf->e_shnum; i++) {
         if (strcmp(section_name, &strtab[shdr[i].sh_name]) == 0) {
             return (void *)shdr[i].sh_addr;
@@ -24,3 +32,21 @@ void *get_addr(const char *section_name)
     return NULL;
 }
 
+void* get_sym_end(void *start_addr, const char *section_name)
+{
+    Elf64_Ehdr *elf = get_elf_header(section_name);
+    Elf64_Shdr *shdr = (Elf64_Shdr *) ((char *)elf + elf->e_shoff);
+    char *strtab = (char *)elf + shdr[elf->e_shstrndx].sh_offset;
+    for(int i = 0; i < elf->e_shnum; i++) {
+        if (shdr[i].sh_type == SHT_SYMTAB) {
+            Elf64_Sym *stab = (Elf64_Sym *)((char *)elf + shdr[i].sh_offset);
+            int symbol_count = shdr[i].sh_size / sizeof(Elf64_Sym);
+            for (int i = 0; i < symbol_count; ++i) {
+                if ((void *)stab[i].st_value == start_addr) {
+                    return (char *)start_addr + stab[i].st_size;
+                }
+            }
+        }
+    }
+    return NULL;
+}

--- a/src/stackmap_checker/utils.h
+++ b/src/stackmap_checker/utils.h
@@ -5,5 +5,9 @@
  * Return the start address of the specified section.
  */
 void *get_addr(const char *section_name);
+
+/*
+ * Return the end address of the symbol with the specified start address.
+ */
 void* get_sym_end(void *start_addr, const char *section_name);
 #endif // UTILS_H

--- a/src/stackmap_checker/utils.h
+++ b/src/stackmap_checker/utils.h
@@ -5,5 +5,5 @@
  * Return the start address of the specified section.
  */
 void *get_addr(const char *section_name);
-
+void* get_sym_end(void *start_addr, const char *section_name);
 #endif // UTILS_H


### PR DESCRIPTION
This introduces the code necessary to restore the state of each frame whenever a guard fails. This should also restore the register state.

To implement this, it was also necessary to:
* remove the `MachineFunctionPass` I'd implemented and modify the `emitPrologue` and `emitEpilogue` code in `lib/Target/X86/X86FrameLowering.cpp` to ensure each optimized function has the same stack size as its unoptimized version
* implement a crude version of live variable analysis in `CheckPointPass.cpp` (closes #2)
* insert a `stackmap` call after each call to a function defined in the module being processed (also implemented in `CheckPointPass`). This allows the runtime to obtain a record of all the locations that are live at each call site. The address of the stackmap is automatically recorded, which allows the runtime to work out the return addresses of the 'unoptimized' functions. (closes #4)

I've done my best to document my code, but I am aware it may not always be obvious what it does. Please let me know which parts are unclear/should be reimplemented.

(Also closes #6 as far as I can tell)