### PR TITLE
Restore locations larger than sizeof(uint64_t).

### DIFF
--- a/src/stackmap_checker/stmap.h
+++ b/src/stackmap_checker/stmap.h
@@ -112,8 +112,9 @@ stack_size_record_t* stmap_get_size_record(stack_map_t *sm, uint64_t sm_rec_idx)
 /*
  * Compute the value of the specified location.
  */
-uint64_t stmap_get_location_value(stack_map_t *sm, location_t loc,
-                                  uint64_t *regs, void *frame_addr);
+void stmap_get_location_value(stack_map_t *sm, location_t loc,
+                              uint64_t *regs, void *frame_addr,
+                              void **loc_value, uint64_t loc_size);
 
 /*
  * Return the stack map/size record pair which describes the return address in an
@@ -140,8 +141,6 @@ void assert_valid_reg_num(unw_regnum_t reg);
 stack_map_record_t* stmap_get_last_record(stack_map_t *sm,
                                           stack_size_record_t target_size_rec);
 void stmap_print_stack_size_records(stack_map_t *);
-void stmap_print_map_record(stack_map_t *sm, uint32_t rec_idx,
-                            uint64_t *regs, void *frame_addr);
 void stmap_print_liveouts(stack_map_t *rec, uint64_t *regs);
 
 #endif // STMAP_H

--- a/src/tests/test_programs/trace_structs.c
+++ b/src/tests/test_programs/trace_structs.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+
+typedef struct LargeStruct {
+    int a;
+    int b;
+    long c;
+} large_struct_t;
+
+int more_indirection()
+{
+    return 100;
+}
+
+void trace()
+{
+    large_struct_t y;
+    y.a = 1;
+    y.b = 1;
+    y.c = 10000000000;
+    int x = more_indirection();
+    printf("x = %d\n", x);
+    printf("y = %d\n", y.a);
+    printf("z = %ld\n", y.c);
+}
+
+int main(int argc, char **argv)
+{
+    trace();
+    return 0;
+}


### PR DESCRIPTION
This one should be quite straightforward, as it simply fixes  #7.

`stmap_get_location_value` is supposed to return the value stored at any given 'live' location. This function used to return a `uint64_t`, which was incorrect because some locations are too large to be represented as `uint64_t`s.