### PR TITLE
Simplify the helper functions.

### DIFF
--- a/src/stackmap_checker/guard.c
+++ b/src/stackmap_checker/guard.c
@@ -34,6 +34,7 @@ void __guard_failure(int64_t sm_id)
     unw_cursor_t saved_cursor = cursor;
     // Read the stack map section.
     void *stack_map_addr = get_addr(binary_path, ".llvm_stackmaps");
+    free(binary_path);
     if (!stack_map_addr) {
         errx(1, ".llvm_stackmaps section not found. Exiting.\n");
     }
@@ -61,7 +62,7 @@ void __guard_failure(int64_t sm_id)
     call_stack_state_t *state = get_call_stack_state(cursor);
     collect_map_records(state, sm);
     // Get the end address of the function in which a guard failed.
-    void *end_addr = get_sym_end(binary_path, (void *)opt_size_rec->fun_addr);
+    void *end_addr = (void *)get_sym_end(opt_size_rec->fun_addr);
     uint64_t callback_ret_addr = (uint64_t) __builtin_return_address(0);
     // The first frame
     frame_t *fail_frame = alloc_empty_frames(1);
@@ -87,6 +88,5 @@ void __guard_failure(int64_t sm_id)
     addr = unopt_size_rec->fun_addr + unopt_rec->instr_offset;
     stmap_free(sm);
     free_call_stack_state(state);
-    free(binary_path);
     asm volatile("jmp jmp_to_addr");
 }

--- a/src/stackmap_checker/utils.c
+++ b/src/stackmap_checker/utils.c
@@ -20,9 +20,11 @@ char* get_binary_path()
     return buff;
 }
 
-Elf64_Ehdr* get_elf_header(const char *bin_name)
+Elf64_Ehdr* get_elf_header()
 {
+    char *bin_name = get_binary_path();
     int fd = open(bin_name, O_RDONLY);
+    free(bin_name);
     void *data = mmap(NULL,
                       lseek(fd, 0, SEEK_END), // file size
                       PROT_READ,
@@ -33,47 +35,72 @@ Elf64_Ehdr* get_elf_header(const char *bin_name)
     return elf;
 }
 
-void free_header(const char *bin_name, Elf64_Ehdr *elf)
+void free_header(Elf64_Ehdr *elf)
 {
+    char *bin_name = get_binary_path();
     int fd = open(bin_name, O_RDONLY);
+    free(bin_name);
     munmap(elf, lseek(fd, 0, SEEK_END)); // file size
     close(fd);
 }
 
 void* get_addr(const char *bin_name, const char *section_name)
 {
-    Elf64_Ehdr *elf = get_elf_header(bin_name);
+    Elf64_Ehdr *elf = get_elf_header();
     Elf64_Shdr *shdr = (Elf64_Shdr *) ((char *)elf + elf->e_shoff);
     char *strtab = (char *)elf + shdr[elf->e_shstrndx].sh_offset;
     for(int i = 0; i < elf->e_shnum; i++) {
         if (strcmp(section_name, &strtab[shdr[i].sh_name]) == 0) {
             void *addr = (void *)shdr[i].sh_addr;
-            free_header(bin_name, elf);
+            free_header(elf);
             return addr;
         }
     }
-    free_header(bin_name, elf);
+    free_header(elf);
     return NULL;
 }
 
-void* get_sym_end(const char *bin_name, void *start_addr)
+uint64_t get_sym_end(uint64_t start_addr)
 {
-    Elf64_Ehdr *elf = get_elf_header(bin_name);
+    Elf64_Ehdr *elf = get_elf_header();
     Elf64_Shdr *shdr = (Elf64_Shdr *) ((char *)elf + elf->e_shoff);
     char *strtab = (char *)elf + shdr[elf->e_shstrndx].sh_offset;
-    for(int i = 0; i < elf->e_shnum; i++) {
+    for(int i = 0; i < elf->e_shnum; ++i) {
         if (shdr[i].sh_type == SHT_SYMTAB) {
             Elf64_Sym *stab = (Elf64_Sym *)((char *)elf + shdr[i].sh_offset);
             int symbol_count = shdr[i].sh_size / sizeof(Elf64_Sym);
             for (int i = 0; i < symbol_count; ++i) {
-                if ((void *)stab[i].st_value == start_addr) {
+                if (stab[i].st_value == start_addr) {
                     void *addr = (char *)start_addr + stab[i].st_size;
-                    free_header(bin_name, elf);
+                    free_header(elf);
+                    return (uint64_t)addr;
+                }
+            }
+        }
+    }
+    free_header(elf);
+    return 0;
+}
+
+uint64_t get_sym_start(uint64_t addr)
+{
+    Elf64_Ehdr *elf = get_elf_header();
+    Elf64_Shdr *shdr = (Elf64_Shdr *) ((char *)elf + elf->e_shoff);
+    char *strtab = (char *)elf + shdr[elf->e_shstrndx].sh_offset;
+    for(int i = 0; i < elf->e_shnum; ++i) {
+        if (shdr[i].sh_type == SHT_SYMTAB) {
+            Elf64_Sym *stab = (Elf64_Sym *)((char *)elf + shdr[i].sh_offset);
+            int symbol_count = shdr[i].sh_size / sizeof(Elf64_Sym);
+            for (int i = 0; i < symbol_count; ++i) {
+                uint64_t end_addr = get_sym_end(stab[i].st_value);
+                if (stab[i].st_value <= addr && addr < end_addr) {
+                    uint64_t addr = stab[i].st_value;
+                    free_header(elf);
                     return addr;
                 }
             }
         }
     }
-    free_header(bin_name, elf);
-    return NULL;
+    free_header(elf);
+    return 0;
 }

--- a/src/stackmap_checker/utils.h
+++ b/src/stackmap_checker/utils.h
@@ -9,7 +9,12 @@ void* get_addr(const char *bin_name, const char *section_name);
 /*
  * Return the end address of the symbol with the specified start address.
  */
-void* get_sym_end(const char *bin_name, void *start_addr);
+uint64_t get_sym_end(uint64_t start_addr);
+
+/*
+ * Return the start address of the function which contains `addr`.
+ */
+uint64_t get_sym_start(uint64_t addr);
 
 /*
  * Return the absolute path of this executable.


### PR DESCRIPTION
This adds a utility function that returns the start address of a function, given an address between its start address and end address. I've also simplified most of the helper functions, by removing the `bin_name` parameter (it's no longer necessary to always pass the path of the binary as an argument).

Note: I am mostly working on the report now, but I've realized there is quite a bit of code I haven't merged into master yet. 