### PR TITLE
Make calls through patchpoints in unopt functions.

### DIFF
--- a/src/passes/function_passes/CheckPointPass.cpp
+++ b/src/passes/function_passes/CheckPointPass.cpp
@@ -101,10 +101,16 @@ struct CheckPointPass: public FunctionPass {
             intrinsic = Intrinsic::getDeclaration(
                 mod, Intrinsic::experimental_patchpoint_void);
           } else {
-            // The function is not optimized -> insert a stackmap call instead
-            // of a patchpoint call.
+            // The function is not optimized -> insert a patchpoint call with
+            // no callback
+            auto callback = builder.CreateIntToPtr(builder.getInt64(0),
+                                                   builder.getInt8PtrTy());
+            args.insert(args.end(),
+                        { callback,              // no callback
+                          builder.getInt32(0),   // the callback has no arguments
+                        });
             intrinsic = Intrinsic::getDeclaration(
-                mod, Intrinsic::experimental_stackmap);
+                mod, Intrinsic::experimental_patchpoint_void);
           }
           auto callInst = builder.CreateCall(intrinsic, args);
         } else if (isa<CallInst>(it)) {

--- a/src/stackmap_checker/Makefile
+++ b/src/stackmap_checker/Makefile
@@ -1,4 +1,5 @@
 CC := clang
+CFLAGS := -g
 LLC := ../llvm/build/bin/llc
 CPOINTPASS := -Xclang -load -Xclang ../passes/build/function_passes/libCheckPointPass.so
 UNOPTPASS := -Xclang -load -Xclang ../passes/build/function_passes/libUnoptimizedCopyPass.so
@@ -25,6 +26,7 @@ bytecode: $(PREFIX)%.c
 $(TARGET_OBJS): $$(basename $$@).ll
 	$(LLC) -filetype=obj $<
 	$(LLC) -filetype=obj $<
+	rm .stack_resizer_*
 
 %.ll: %.c
 	$(CC) $(PASSFLAGS) -S -emit-llvm $< -O3

--- a/src/tests/test_programs/Makefile
+++ b/src/tests/test_programs/Makefile
@@ -32,6 +32,7 @@ bytecode: $(TRACE_PREFIX)%.c
 $(TARGET_OBJS): $$(basename $$@).ll
 	$(LLC) -filetype=obj $<
 	$(LLC) -filetype=obj $<
+	rm .stack_resizer_*
 
 %.ll: %.c
 	$(CC) $(PASSFLAGS) -S -emit-llvm $< -O3


### PR DESCRIPTION
This replaces the `stackmap` in the unoptimized version of the function which triggered the guard failure with  a `patchpoint` that takes a null callback. This is because all unoptimized functions must record the state using `patchpoint` calls, and not `stackmap` calls (as described in #14).